### PR TITLE
feat: Add path config on Secrets Manager prefix for Keys

### DIFF
--- a/backend/cmd/bff/main.go
+++ b/backend/cmd/bff/main.go
@@ -312,13 +312,13 @@ func initializeServices(
 		credentialStore, err = idpcore.NewAwsSmCredentialStore(
 			&awscfg,
 			nil,
-			&config.AwsSecretsPrefix,
+			config.AwsSecretsPrefix,
 		)
 		if err != nil {
 			log.Fatal("unable to create AWS SM client ", err)
 		}
 
-		keyStore, err = identitycore.NewAwsSmKeyStore(&awscfg, nil)
+		keyStore, err = identitycore.NewAwsSmKeyStore(&awscfg, nil, config.AwsSecretsPrefix)
 		if err != nil {
 			log.Fatal("unable to create AWS SM key store ", err)
 		}

--- a/backend/internal/core/identity/key.go
+++ b/backend/internal/core/identity/key.go
@@ -58,10 +58,14 @@ func NewVaultKeyStore(
 	}, nil
 }
 
-func NewAwsSmKeyStore(awsCfg *aws.Config, kmsKeyID *string) (KeyStore, error) {
+func NewAwsSmKeyStore(
+	awsCfg *aws.Config,
+	kmsKeyID *string,
+	secretsPrefix string,
+) (KeyStore, error) {
 	config := keystore.AwsSmStorageConfig{
 		AwsCfg:      awsCfg,
-		MountPath:   "identity-service",
+		MountPath:   secretsPrefix,
 		KeyBasePath: "keys",
 		KmsKeyID:    kmsKeyID,
 	}

--- a/backend/internal/core/idp/credential_aws_sm.go
+++ b/backend/internal/core/idp/credential_aws_sm.go
@@ -18,13 +18,13 @@ import (
 type AwsSmCredentialStore struct {
 	client        *secretsmanager.Client
 	kmsKeyID      *string
-	secretsPrefix *string
+	secretsPrefix string
 }
 
 func NewAwsSmCredentialStore(
 	cfg *aws.Config,
 	kmsKeyID *string,
-	secretsPrefix *string,
+	secretsPrefix string,
 ) (CredentialStore, error) {
 	if cfg == nil {
 		return nil, errors.New("please provide a configuration for the AWS SM client")
@@ -113,7 +113,7 @@ func (s *AwsSmCredentialStore) Delete(ctx context.Context, subject string) error
 func (s *AwsSmCredentialStore) getSecretPath(tenantID, subject string) string {
 	return fmt.Sprintf(
 		"%s/%s/%s/%s",
-		ptrutil.DerefStr(s.secretsPrefix),
+		s.secretsPrefix,
 		mountPath,
 		tenantID,
 		subject,


### PR DESCRIPTION
# Description

Add prefix for AWS Secret Manager + Keys.

## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/outshift-open/identity-service/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
