### PR TITLE
fix add persist credential to push to gh-pages

### DIFF
--- a/.github/workflows/reusable-helm.yml
+++ b/.github/workflows/reusable-helm.yml
@@ -29,7 +29,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          persist-credentials: false
+          persist-credentials: true
+          token: ${{ secrets.github-token }}
 
       - name: Configure Git
         run: |


### PR DESCRIPTION
# Description

add persist cred to update index on gh-pages branch.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/outshift-open/identity-service/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
