### PR TITLE
chore: remove outside packages from precommit sdk

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,13 @@ repos:
           "-s=only"
         ]
         files: \.(go|ts|tsx|js|jsx|py|sh|yaml|yml|css|scss)$
+        exclude: |
+          (?x)^(
+            sdk/python/(agntcy|google|openapiv3)/         # generated python proto bindings
+            |backend/api/spec/proto/                      # .proto sources + generated (pb.go in same tree)
+            |backend/api/server/.*\.pb\.go$               # other generated Go protobufs
+            |backend/api/spec/static/api/openapi/         # generated openapi yaml
+          )
 
   - repo: https://github.com/tekwizely/pre-commit-golang
     rev: v1.0.0-rc.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,14 +8,18 @@ repos:
     rev: v1.2.0
     hooks:
       - id: addlicense # Add license header to files
-        args: [
-          "-ignore","**/node_modules/**",
-          "-ignore","**/vendor/**",
-          "-ignore","**/.mockery.yaml",
-          "-c","Copyright AGNTCY Contributors (https://github.com/agntcy)",
-          "-l","Apache-2.0",
-          "-s=only"
-        ]
+        args:
+          - -ignore
+          - '**/node_modules/**'
+          - -ignore
+          - '**/vendor/**'
+          - -ignore
+          - '**/.mockery.yaml'
+          - -c
+          - 'Copyright AGNTCY Contributors (https://github.com/agntcy)'
+          - -l
+          - Apache-2.0
+          - -s=only
         files: \.(go|ts|tsx|js|jsx|py|sh|yaml|yml|css|scss)$
         exclude: |
           (?x)^(

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,14 @@ repos:
     rev: v1.2.0
     hooks:
       - id: addlicense # Add license header to files
-        args: ["-ignore", "**/node_modules/**", "-ignore", "**/vendor/**", "-ignore", "**/.mockery.yaml", "-c", "Copyright AGNTCY Contributors (https://github.com/agntcy)", "-l", "Apache-2.0", "-s=only", "."]
+        args: [
+          "-ignore","**/node_modules/**",
+          "-ignore","**/vendor/**",
+          "-ignore","**/.mockery.yaml",
+          "-c","Copyright AGNTCY Contributors (https://github.com/agntcy)",
+          "-l","Apache-2.0",
+          "-s=only"
+        ]
         files: \.(go|ts|tsx|js|jsx|py|sh|yaml|yml|css|scss)$
 
   - repo: https://github.com/tekwizely/pre-commit-golang

--- a/sdk/python/.pre-commit-config.yaml
+++ b/sdk/python/.pre-commit-config.yaml
@@ -1,6 +1,7 @@
 # Copyright 2025 AGNTCY Contributors (https://github.com/agntcy)
 # SPDX-License-Identifier: Apache-2.0
 
+---
 default_stages: [pre-commit, pre-push]
 exclude: |
   ^(agntcy|google|openapiv3)/

--- a/sdk/python/.pre-commit-config.yaml
+++ b/sdk/python/.pre-commit-config.yaml
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 default_stages: [pre-commit, pre-push]
-exclude: (sdk/python/agntcy/.*)
+exclude: |
+  ^(agntcy|google|openapiv3)/
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.6.0

--- a/sdk/python/.pre-commit-config.yaml
+++ b/sdk/python/.pre-commit-config.yaml
@@ -23,10 +23,10 @@ repos:
   hooks:
     - id: ruff
       args: [--fix]
-      types_or: [ python, pyi, jupyter ]
+      types_or: [python, pyi, jupyter]
       files: identityservice
     - id: ruff-format
-      types_or: [ python, pyi, jupyter ]
+      types_or: [python, pyi, jupyter]
 
 - repo: https://github.com/srstevenson/nb-clean
   rev: 3.3.0


### PR DESCRIPTION
# Description
args: [..., "-s=only", "."]

That final "." makes addlicense recursively scan the entire repo, bypassing pre-commit’s file filtering.

the workflow runs with arg --all-file, so need to exclude some auto generated files.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/identity-service/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
