### PR TITLE
fix: add audience JWT check

### DIFF
--- a/backend/cmd/bff/configuration.go
+++ b/backend/cmd/bff/configuration.go
@@ -39,6 +39,7 @@ type Configuration struct {
 	IamIssuer                                               string        `split_words:"true"`
 	IamUserCidClaimName                                     string        `split_words:"true" default:"cid"`
 	IamUserCid                                              string        `split_words:"true"`
+	IamAudience                                             string        `split_words:"true" default:"api://default"`
 	IamOrganization                                         string        `split_words:"true"`
 	IamMultiTenant                                          bool          `split_words:"true" default:"false"`
 	WebApprovalEmail                                        string        `split_words:"true"                                 required:"true"`

--- a/backend/cmd/bff/main.go
+++ b/backend/cmd/bff/main.go
@@ -210,6 +210,7 @@ func initializeIAMClient(
 			config.IamIssuer,
 			config.IamUserCid,
 			config.IamUserCidClaimName,
+			config.IamAudience,
 		)
 		iamClient = iam.NewStandaloneClient(
 			config.IamOrganization,

--- a/backend/internal/pkg/iam/iam_standalone.go
+++ b/backend/internal/pkg/iam/iam_standalone.go
@@ -18,7 +18,6 @@ import (
 )
 
 const (
-	standaloneDefaultAud            = "api://default"
 	standaloneUsernameClaimKey      = "sub"
 	standaloneApiKeyName            = "default"
 	standaloneApiKeyLength          = 32

--- a/backend/internal/pkg/iam/jwt.go
+++ b/backend/internal/pkg/iam/jwt.go
@@ -17,12 +17,12 @@ type oktaJwtVerifier struct {
 	userJwtVerifier *jwtverifier.JwtVerifier
 }
 
-func NewOktaJwtVerifier(issuer, userCid, userCidClaimName string) JwtVerifier {
+func NewOktaJwtVerifier(issuer, userCid, userCidClaimName, audience string) JwtVerifier {
 	// Init verifier for UI
 	toValidateForUser := map[string]string{}
 
 	// Add cid from UI
-	toValidateForUser["aud"] = standaloneDefaultAud
+	toValidateForUser["aud"] = audience
 	toValidateForUser[userCidClaimName] = userCid
 
 	userJwtVerifierSetup := jwtverifier.JwtVerifier{


### PR DESCRIPTION
# Description

Add `IAM_AUDIENCE` ENV var for OIDC backend JWT verification. This serves as a way to have more flexibility working with OIDC providers.

## Type of Change

- [ ] Bugfix
- [X] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [X] I have read the [contributing guidelines](/agntcy/identity-service/blob/main/CONTRIBUTING.md)
- [X] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [X] Functionality is documented
- [X] All code style checks pass
- [X] New code contribution is covered by automated tests
- [X] All new and existing tests pass
