### PR TITLE
feat(node): propagated request ID to Identity Node

### DIFF
--- a/backend/internal/core/identity/transport.go
+++ b/backend/internal/core/identity/transport.go
@@ -1,0 +1,36 @@
+// Copyright 2025 AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+package identity
+
+import (
+	"net/http"
+
+	identitycontext "github.com/agntcy/identity-service/internal/pkg/context"
+)
+
+// transportWithRequestID is an HTTP transport that propagates the request ID to the Identity Node
+type transportWithRequestID struct {
+	Transport http.RoundTripper
+}
+
+func (t *transportWithRequestID) RoundTrip(req *http.Request) (*http.Response, error) {
+	reqID, ok := identitycontext.GetRequestID(req.Context())
+	if !ok || reqID == "" {
+		return t.Transport.RoundTrip(req)
+	}
+
+	if req.Header == nil {
+		req.Header = make(http.Header)
+	}
+
+	req.Header.Add("X-Request-Id", reqID)
+
+	return t.Transport.RoundTrip(req)
+}
+
+func newTransportWithRequestID() *transportWithRequestID {
+	return &transportWithRequestID{
+		Transport: http.DefaultTransport,
+	}
+}

--- a/backend/internal/core/identity/transport_test.go
+++ b/backend/internal/core/identity/transport_test.go
@@ -1,0 +1,97 @@
+// Copyright 2025 AGNTCY Contributors (https://github.com/agntcy)
+// SPDX-License-Identifier: Apache-2.0
+
+//nolint:testpackage // this file is testing a private struct
+package identity
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	identitycontext "github.com/agntcy/identity-service/internal/pkg/context"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+func createTestServerWithReqHeadersPropagation(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		for k, v := range r.Header {
+			w.Header().Add(k, v[0])
+		}
+
+		_, _ = w.Write([]byte(uuid.NewString()))
+	}))
+}
+
+func TestTransportWithRequestID_should_inject_request_id_in_http_request(t *testing.T) {
+	t.Parallel()
+
+	ts := createTestServerWithReqHeadersPropagation(t)
+	defer ts.Close()
+
+	requestID := uuid.NewString()
+	ctx := identitycontext.InsertRequestID(t.Context(), requestID)
+
+	transport := newTransportWithRequestID()
+	client := http.Client{
+		Transport: transport,
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL, http.NoBody)
+	assert.NoError(t, err)
+
+	resp, err := client.Do(req)
+
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	assert.NoError(t, err)
+	assert.Equal(t, requestID, resp.Header.Get("X-Request-Id"))
+}
+
+func TestTransportWithRequestID_should_not_inject_request_id_in_http_request(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]*struct {
+		ctx context.Context //nolint:containedctx // essential part of the test case
+	}{
+		"empty request ID in context": {
+			ctx: identitycontext.InsertRequestID(t.Context(), ""),
+		},
+		"context without request ID": {
+			ctx: t.Context(),
+		},
+	}
+
+	for tn, tc := range testCases {
+		t.Run(tn, func(t *testing.T) {
+			t.Parallel()
+
+			ts := createTestServerWithReqHeadersPropagation(t)
+			defer ts.Close()
+
+			transport := newTransportWithRequestID()
+			client := http.Client{Transport: transport}
+
+			req, err := http.NewRequestWithContext(tc.ctx, http.MethodGet, ts.URL, http.NoBody)
+			assert.NoError(t, err)
+
+			resp, err := client.Do(req)
+
+			defer func() {
+				_ = resp.Body.Close()
+			}()
+
+			assert.NoError(t, err)
+
+			v, exists := resp.Header[http.CanonicalHeaderKey("X-Request-Id")]
+			assert.False(t, exists)
+			assert.Empty(t, v)
+		})
+	}
+}


### PR DESCRIPTION
# Description

The idea is to propagate the request ID generated by the `RequestIdUnary` gRPC interceptor to the Identity Node when making HTTP calls by adding `X-Request-Id` header, this will make identifying logs related to a specific request easier (end-to-end).

## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/identity-service/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
