### PR TITLE
Revise User Context to Subject Context Transfer

### DIFF
--- a/docs/contribute/wip/2_User_Context/statement.md
+++ b/docs/contribute/wip/2_User_Context/statement.md
@@ -1,4 +1,3 @@
-# User Context
+# Subject Context Transfer
 
-How user context can be passed, embedded into tokens, and leveraged in scopes that inform policy decision points.
-This affects traceability, compliance, and fine-grained authorization.
+This Sub-Group (SG) addresses subject context transfers and bindings enabling policy decisions across a delegated chain that may involve users, agents, and tools. Issues like how such contexts should be embedded into tokens and leveraged to inform policy decision points, enable fine-grained authorization, traceability, and compliance are within the scope of this SG. This SG will also identify relevant standards, other ongoing initiatives, and push for new specs for the gaps identified.  


### PR DESCRIPTION
Updated the section to focus on subject context transfer and its implications for policy decisions.
