### PR TITLE
docs: Add meeting notes for November 10th, 2025

### DIFF
--- a/docs/contribute/wip/2_User_Context/meeting_notes/2025-11-10.md
+++ b/docs/contribute/wip/2_User_Context/meeting_notes/2025-11-10.md
@@ -2,16 +2,16 @@
 
 November 10th, 2025
 
-# Attendees
+## Attendees
 
 - Tomer Elias (Human)
 - Jean Diaconu (Cisco)
 - Ankit Agarwal (Skyfire)
 - Marcelo Yannuzzi (Cisco)
 
-# Notes
+## Notes
 
-## Discussed:
+### Discussed:
 
 - Problem Statement and Goals
 - Main Requirements Discussion
@@ -23,7 +23,7 @@ November 10th, 2025
 	  3. Once the entity that exchanged the token got access to the subject's access token, it can keep reusing and exchanging it
 	  4. The chain matters (sec anc compliance)
  		
-# Next Steps
+## Next Steps
 
 - Elaborate on the gaps and needs in terms of requirements
 - Identify gaps that require new specs


### PR DESCRIPTION
Documented meeting notes from November 10th, 2025, including attendees, discussion points, and next steps regarding user context and standards analysis.

# Description

Added meeting notes for the context transfer subgroup

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [x] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/identity-service/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
