### PR TITLE
chore: remove useless async method

### DIFF
--- a/sdk/python/identityservice/badge/claims.py
+++ b/sdk/python/identityservice/badge/claims.py
@@ -56,7 +56,7 @@ async def create_claims(url: str, service_name: str, service_type: AppType):
         )
 
         # For OASF, we assume the URL is a path to the OASF JSON file
-        schema = await oasf.discover(url)
+        schema = oasf.discover(url)
 
         claims["oasf"] = {
             "schema_base64": base64.b64encode(schema.encode("utf-8")),

--- a/sdk/python/identityservice/badge/oasf.py
+++ b/sdk/python/identityservice/badge/oasf.py
@@ -7,7 +7,7 @@ import os
 from identityservice.exceptions import SdkError
 
 
-async def discover(url: str) -> str:
+def discover(url: str) -> str:
     """Load an OASF schema from a local JSON file.
 
     For OASF, we assume ``url`` is a path to the OASF JSON file that

--- a/sdk/python/tests/unit/badge/test_claims.py
+++ b/sdk/python/tests/unit/badge/test_claims.py
@@ -72,7 +72,6 @@ async def test_create_claims_for_oasf_agent():
     # Act
     with patch(
         "identityservice.badge.oasf.discover",
-        new_callable=AsyncMock,
         return_value=oasf_schema,
     ) as mock_oasf_discover:
         claims = await create_claims(service_url, "", service_type)

--- a/sdk/python/tests/unit/badge/test_oasf.py
+++ b/sdk/python/tests/unit/badge/test_oasf.py
@@ -10,34 +10,31 @@ from identityservice.badge import oasf
 from identityservice.exceptions import SdkError
 
 
-@pytest.mark.asyncio
-async def test_discover_success(tmp_path: Path):
+def test_discover_success(tmp_path: Path):
     """discover should return file contents when file exists and is non-empty."""
     schema_path = tmp_path / "oasf.json"
     content = '{"version": "1.0.0", "name": "Test OASF Agent"}'
     schema_path.write_text(content, encoding="utf-8")
 
-    result = await oasf.discover(str(schema_path))
+    result = oasf.discover(str(schema_path))
 
     assert result == content
 
 
-@pytest.mark.asyncio
-async def test_discover_raises_when_file_missing():
+def test_discover_raises_when_file_missing():
     """discover should raise SdkError when file does not exist."""
     with pytest.raises(SdkError) as excinfo:
-        await oasf.discover("/non/existent/oasf.json")
+        oasf.discover("/non/existent/oasf.json")
 
     assert "OASF schema file not found" in str(excinfo.value)
 
 
-@pytest.mark.asyncio
-async def test_discover_raises_when_file_empty(tmp_path: Path):
+def test_discover_raises_when_file_empty(tmp_path: Path):
     """discover should raise SdkError when file is empty."""
     schema_path = tmp_path / "empty.json"
     schema_path.write_text("", encoding="utf-8")
 
     with pytest.raises(SdkError) as excinfo:
-        await oasf.discover(str(schema_path))
+        oasf.discover(str(schema_path))
 
     assert "OASF schema file is empty" in str(excinfo.value)


### PR DESCRIPTION
# Description

remove useless async method because read is sync.

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/identity-service/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
