### PR TITLE
fix: Remove previous settings when non empty

### DIFF
--- a/backend/internal/core/settings/postgres/repository.go
+++ b/backend/internal/core/settings/postgres/repository.go
@@ -81,9 +81,11 @@ func (r *repository) UpdateIssuerSettings(
 			return fmt.Errorf("there was an error updating the settings: %w", updated.Error)
 		}
 
-		err = tx.Where("id = ?", previousIdpSettingsID).Delete(emptyIdpSettings).Error
-		if err != nil {
-			return err
+		if previousIdpSettingsID != uuid.Nil {
+			err = tx.Where("id = ?", previousIdpSettingsID).Delete(emptyIdpSettings).Error
+			if err != nil {
+				return err
+			}
 		}
 
 		return nil


### PR DESCRIPTION
# Description

This pull request introduces a small but important fix to the `UpdateIssuerSettings` method in the `repository.go` file. The change ensures that the code only attempts to delete previous IdP settings if a valid `previousIdpSettingsID` is present, preventing potential errors when the ID is not set.

* Added a conditional check to only delete previous IdP settings if `previousIdpSettingsID` is not `uuid.Nil` in the `UpdateIssuerSettings` method of `repository.go`.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/identity-service/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass