### PR TITLE
docs: add placeholder READMEs for conference demo dirs

### DIFF
--- a/demos/cncf-demo/README.md
+++ b/demos/cncf-demo/README.md
@@ -1,0 +1,17 @@
+# CNCF Demo
+
+> **Placeholder** — content coming soon.
+
+This directory will host the CNCF conference demo stack for AGNTCY Identity Service.
+
+## Planned contents
+
+- `docker-compose.yaml` — supporting services (Keycloak, Gitea).
+- Envoy + `ext_authz` configuration for task-based authorization.
+- Demo walkthrough and run instructions.
+
+## Related issues
+
+- Create a docker-compose file: [#227](https://github.com/agntcy/identity-service/issues/227)
+- Set up Envoy and ext_authz: [#228](https://github.com/agntcy/identity-service/issues/228)
+- Move `agenticidentity-cncf` into this directory: [#229](https://github.com/agntcy/identity-service/issues/229)

--- a/demos/xaa-multi-enterprise/README.md
+++ b/demos/xaa-multi-enterprise/README.md
@@ -1,0 +1,14 @@
+# XAA Multi-Enterprise Demo
+
+> **Placeholder** — content coming soon.
+
+This directory will host the cross-enterprise (XAA) multi-enterprise demo for AGNTCY Identity Service.
+
+## Planned contents
+
+- Multi-enterprise agent identity and authorization demo.
+- Setup and run instructions.
+
+## Related issues
+
+- Move `agntcyXAA-MultiEnterprise` into this directory: [#230](https://github.com/agntcy/identity-service/issues/230)


### PR DESCRIPTION
## Summary

- Add placeholder `README.md` files for the two upcoming conference demo directories:
  - `demos/cncf-demo/README.md`
  - `demos/xaa-multi-enterprise/README.md`
- Each README describes the planned contents and links to the tracking issues.

These are scaffolding placeholders so the demo work (#227–#230) has a home in the repo.

## Test plan

- [ ] Confirm both READMEs render correctly on GitHub.
- [ ] Confirm directory paths match the intended demo layout.

Refs #227, #228, #229, #230

Made with [Cursor](https://cursor.com)