### PR TITLE
feat(demos): add cncf-stack docker-compose (keycloak, gitea, identity node)

### DIFF
--- a/demos/cncf-stack/.env.example
+++ b/demos/cncf-stack/.env.example
@@ -30,3 +30,13 @@ IAM_ORGANIZATION=cncf-demo
 SECRETS_CRYPTO_KEY=change-me-crypto-key-min-16-chars
 IAM_ISSUER=http://keycloak:8080/realms/cncf-demo
 IAM_USER_CID=cncf-demo-client
+
+# ---------- ID-JAG web app ----------
+WEBAPP_PORT=8000
+# The web app talks to Keycloak using the credentials baked into the imported
+# realm (keycloak/cncf-demo-realm.json). If you change those, override here:
+# CNCF_CLIENT_SECRET=demo-client-secret-change-me
+# CNCF_BACKEND_SECRET=demo-backend-secret-change-me
+# CNCF_DEMO_USER=sarah
+# CNCF_DEMO_PASSWORD=demo-password-change-me
+# CNCF_IDJAG_SUBJECT=sarah@enterprisex.com

--- a/demos/cncf-stack/.env.example
+++ b/demos/cncf-stack/.env.example
@@ -29,14 +29,16 @@ IDENTITY_NODE_GRPC_PORT=4004
 IAM_ORGANIZATION=cncf-demo
 SECRETS_CRYPTO_KEY=change-me-crypto-key-min-16-chars
 IAM_ISSUER=http://keycloak:8080/realms/cncf-demo
-IAM_USER_CID=cncf-demo-client
+IAM_USER_CID=requesting-app
 
 # ---------- ID-JAG web app ----------
+# Cross-App Access demo: the Requesting App gets access to the Receiving App
+# on behalf of the signed-in user, via an ID-JAG assertion.
 WEBAPP_PORT=8000
 # The web app talks to Keycloak using the credentials baked into the imported
 # realm (keycloak/cncf-demo-realm.json). If you change those, override here:
-# CNCF_CLIENT_SECRET=demo-client-secret-change-me
-# CNCF_BACKEND_SECRET=demo-backend-secret-change-me
-# CNCF_DEMO_USER=sarah
+# CNCF_REQUESTING_SECRET=demo-requesting-secret-change-me
+# CNCF_RECEIVING_SECRET=demo-receiving-secret-change-me
+# CNCF_DEMO_USER=user
 # CNCF_DEMO_PASSWORD=demo-password-change-me
-# CNCF_IDJAG_SUBJECT=sarah@enterprisex.com
+# CNCF_IDJAG_SUBJECT=user@example.com

--- a/demos/cncf-stack/.env.example
+++ b/demos/cncf-stack/.env.example
@@ -1,0 +1,32 @@
+# CNCF demo stack — example environment file.
+#
+# Copy to .env and change every value before use:
+#   cp .env.example .env
+#
+# These are LOCAL DEMO defaults only. Do NOT reuse them anywhere real.
+
+# ---------- Keycloak ----------
+KEYCLOAK_ADMIN=admin
+KEYCLOAK_ADMIN_PASSWORD=change-me-admin
+KEYCLOAK_HTTP_PORT=8080
+
+# ---------- Gitea ----------
+GITEA_HTTP_PORT=3000
+GITEA_SSH_PORT=2222
+GITEA_ROOT_URL=http://localhost:3000/
+
+# ---------- Identity node: Postgres ----------
+DB_USERNAME=postgres
+DB_PASSWORD=change-me-postgres
+DB_NAME=identity
+
+# ---------- Identity node: Vault (dev mode) ----------
+VAULT_DEV_ROOT_TOKEN=change-me-devroot
+
+# ---------- Identity node ----------
+IDENTITY_NODE_REST_PORT=4003
+IDENTITY_NODE_GRPC_PORT=4004
+IAM_ORGANIZATION=cncf-demo
+SECRETS_CRYPTO_KEY=change-me-crypto-key-min-16-chars
+IAM_ISSUER=http://keycloak:8080/realms/cncf-demo
+IAM_USER_CID=cncf-demo-client

--- a/demos/cncf-stack/.env.example
+++ b/demos/cncf-stack/.env.example
@@ -14,6 +14,13 @@ KEYCLOAK_HTTP_PORT=8080
 GITEA_HTTP_PORT=3000
 GITEA_SSH_PORT=2222
 GITEA_ROOT_URL=http://localhost:3000/
+# Admin user seeded by gitea-init; the gateway uses these to reach the Gitea API.
+GITEA_ADMIN_USER=demo-admin
+GITEA_ADMIN_PASSWORD=change-me-gitea-admin
+GITEA_ADMIN_EMAIL=admin@example.com
+
+# ---------- Gitea gateway (ID-JAG narrow-scope enforcement) ----------
+GITEA_GATEWAY_PORT=9100
 
 # ---------- Identity node: Postgres ----------
 DB_USERNAME=postgres

--- a/demos/cncf-stack/.gitignore
+++ b/demos/cncf-stack/.gitignore
@@ -3,3 +3,8 @@
 
 # Keep the example template tracked (root .gitignore ignores .env.*)
 !.env.example
+
+# Python test virtualenv + caches
+.venv/
+__pycache__/
+.pytest_cache/

--- a/demos/cncf-stack/.gitignore
+++ b/demos/cncf-stack/.gitignore
@@ -1,0 +1,5 @@
+# Local env file with real values — never commit
+.env
+
+# Keep the example template tracked (root .gitignore ignores .env.*)
+!.env.example

--- a/demos/cncf-stack/README.md
+++ b/demos/cncf-stack/README.md
@@ -406,6 +406,56 @@ runs the whole sequence at once). Everything runs server-side (no browser CORS):
 The UI shows the decoded header + claims for each token, and the gateway's JSON
 response for the Gitea hops.
 
+### "How it works" tab
+
+The web app has a second tab, **How it works**, that documents the demo for
+presenters rather than running it. It explains how Keycloak is configured for
+token exchange and ID-JAG / Cross-App Access (the experimental feature flags,
+the `receiving-app` client attributes, the `id-jag` identity provider, and the
+`kcadm`-registered narrow scopes) with copy-pasteable snippets, and adds extra
+sequence diagrams beyond the live flow:
+
+- **One-time trust setup** — how Keycloak learns to trust the issuer's JWKS and
+  how `kc-init` registers the narrow scopes.
+- **Exchange & narrow-scoping enforcement** — a close-up of the `jwt-bearer`
+  exchange and the gateway's scope check (including the 403 on write).
+- **Issuing a VC (Badge) with the identity node** — how the identity node
+  registers an issuer, generates a resolvable identity, and publishes/verifies a
+  Verifiable Credential.
+- **VC-backed ID-JAG (proposed)** — how an agent VC would be verified via the
+  identity node alongside the user-delegated ID-JAG token, combining delegated
+  access with verifiable agent identity.
+
+The identity node is included in this section because ID-JAG proves *the user
+authorized this app*, while a VC proves *this app/agent is who it claims to be*.
+See [Identity node & Verifiable Credentials](#identity-node--verifiable-credentials-not-yet-wired-in)
+below for the integration status.
+
+### Identity node & Verifiable Credentials (not yet wired in)
+
+The stack runs the AGNTCY identity node (REST `:4003`, gRPC `:4004`), a registry
+and resolver for agent/app identities and their VCs (AGNTCY **Badges** —
+`AgentBadge` / `McpBadge`, W3C VCs in a JOSE envelope). Relevant endpoints:
+
+| Node endpoint (`/v1alpha1`) | Purpose |
+| --------------------------- | ------- |
+| `POST /issuer/register` | Register a tenant issuer + its public JWK |
+| `POST /id/generate` | Mint a resolvable identity (`ResolverMetadata`) from an OIDC proof |
+| `POST /vc/publish` | Store a signed VC (validates the OIDC proof against the subject) |
+| `POST /vc/verify` | Cryptographically verify a VC |
+| `GET /vc/{id}/.well-known/vcs.json` | Public resolution of an identity's VCs |
+
+VC **signing** happens in the Identity Service BFF (with the tenant key from
+Vault); the node **publishes / resolves / verifies**. This stack currently runs
+the node but **not** the BFF, so live VC issuance is not yet wired into the
+ID-JAG flow — the "VC-backed ID-JAG" sequence is a design (per AGNTCY's DCR
+`vc+jwt` / Client-ID-Metadata proposal). To make it live you would either run
+the Identity Service BFF, or have `idjag-issuer` double as a VC issuer (it
+already holds an RSA key + JWKS): register with the node, sign a Badge for
+`requesting-app`, publish it, add the `resolver_metadata_id` as a claim in the
+ID-JAG assertion, and have the gateway call `/vc/verify` before allowing the
+Gitea call.
+
 ### Narrow scoping with Gitea
 
 Gitea is the demo's **protected resource**, fronted by the `gitea-gateway`. The

--- a/demos/cncf-stack/README.md
+++ b/demos/cncf-stack/README.md
@@ -45,6 +45,30 @@ Postgres password, the Vault dev root token, and the identity node crypto key.
 > The values in `.env.example` are **local demo placeholders only**. Never reuse
 > them in any shared or production environment.
 
+## Realm configuration
+
+The `cncf-demo` realm is version-controlled at
+[`keycloak/cncf-demo-realm.json`](./keycloak/cncf-demo-realm.json) and imported
+automatically on startup (`start-dev --import-realm`, mounted at
+`/opt/keycloak/data/import`). It provisions:
+
+| Object | Name | Purpose |
+| --- | --- | --- |
+| Client | `cncf-demo-client` | Confidential client: standard flow, direct access grants, service accounts, **standard token exchange** enabled. |
+| Client | `backend-client` | **ID-JAG receiver** — exchanges an incoming assertion (`jwt-bearer` grant) for a local access token (`oauth2.jwt.authorization.grant.*`). |
+| Identity provider | `id-jag` | External ID-JAG issuer (OIDC), `jwtAuthorizationGrantEnabled=true`. Issuer URLs are **placeholders** — point them at your real IdP. |
+| Users | `sarah`, `alice` | Demo users. |
+
+> **Demo credentials only.** The client secrets and user passwords in the realm
+> file are obvious `*-change-me` placeholders for local use. Change them (and the
+> `id-jag` issuer URLs / client secret) before using this beyond a laptop. To
+> regenerate/extend the realm, edit the JSON or reconfigure a running instance
+> and re-export.
+
+To edit the realm and re-import cleanly, remove the Keycloak container/volume
+first (`docker compose down`), since `--import-realm` skips realms that already
+exist.
+
 ## Cross-App Access (ID-JAG) & Token Exchange
 
 Keycloak is started with two **experimental** feature flags (see the

--- a/demos/cncf-stack/README.md
+++ b/demos/cncf-stack/README.md
@@ -42,16 +42,18 @@ docker compose ps
 ## Testing the ID-JAG (Cross-App Access) sequence
 
 Open the web app at <http://localhost:8000> and click **Run ID-JAG sequence**.
-Everything runs server-side (no browser CORS) across three hops:
+The demo shows the **Requesting App** obtaining access to the **Receiving App**
+on behalf of the signed-in user. Everything runs server-side (no browser CORS)
+across three hops:
 
-1. **User login** — OIDC password grant against Keycloak (`cncf-demo` realm,
-   `cncf-demo-client`) for the demo user `sarah`.
+1. **Requesting App — user sign-in** — OIDC password grant against Keycloak
+   (`cncf-demo` realm, `requesting-app`) for the demo user `user`.
 2. **Mint ID-JAG** — the `idjag-issuer` service signs an Identity Assertion JWT
-   (`iss` = issuer, `sub` = `sarah@enterprisex.com`, `aud` = the realm issuer,
-   `client_id`/`azp` = `backend-client`).
-3. **Receiver exchange** — the assertion is presented to Keycloak's token
+   (`iss` = issuer, `sub` = `user@example.com`, `aud` = the realm issuer,
+   `client_id`/`azp` = `receiving-app`).
+3. **Receiving App — exchange** — the assertion is presented to Keycloak's token
    endpoint with `grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer` and
-   `client_id=backend-client`; Keycloak validates it against the `id-jag`
+   `client_id=receiving-app`; Keycloak validates it against the `id-jag`
    identity provider (JWKS from the issuer), maps `sub` to the local user via
    its federated identity link, and returns a **local access token**.
 
@@ -84,10 +86,10 @@ automatically on startup (`start-dev --import-realm`, mounted at
 
 | Object | Name | Purpose |
 | --- | --- | --- |
-| Client | `cncf-demo-client` | Confidential client: standard flow, direct access grants, service accounts, **standard token exchange** enabled. |
-| Client | `backend-client` | **ID-JAG receiver** — exchanges an incoming assertion (`jwt-bearer` grant) for a local access token (`oauth2.jwt.authorization.grant.*`). |
+| Client | `requesting-app` | **Requesting App** — confidential client: standard flow, direct access grants, service accounts, **standard token exchange** enabled. Signs the user in and initiates cross-app access. |
+| Client | `receiving-app` | **Receiving App (ID-JAG receiver)** — exchanges an incoming assertion (`jwt-bearer` grant) for a local access token (`oauth2.jwt.authorization.grant.*`). |
 | Identity provider | `id-jag` | External ID-JAG issuer (OIDC), `jwtAuthorizationGrantEnabled=true`. Issuer URLs are **placeholders** — point them at your real IdP. |
-| Users | `sarah`, `alice` | Demo users. |
+| Users | `user` | Demo user (`user@example.com`), federated to the `id-jag` issuer. |
 
 > **Demo credentials only.** The client secrets and user passwords in the realm
 > file are obvious `*-change-me` placeholders for local use. Change them (and the

--- a/demos/cncf-stack/README.md
+++ b/demos/cncf-stack/README.md
@@ -271,10 +271,18 @@ volumes:
 
 ## Testing the ID-JAG (Cross-App Access) sequence
 
-Open the web app at <http://localhost:8000> and click **Run ID-JAG sequence**.
-The demo shows the **Requesting App** obtaining access to the **Receiving App**
-on behalf of the signed-in user. Everything runs server-side (no browser CORS)
-across three hops:
+Open the web app at <http://localhost:8000>. The demo shows the **Requesting
+App** obtaining access to the **Receiving App** on behalf of the signed-in
+user. Two playback modes are available:
+
+- **Run (animated)** — plays all three hops automatically with a short pause
+  between each, highlighting the sequence diagram as it goes.
+- **Next step** — executes one hop per click, so you can narrate each step
+  during a presentation.
+
+Each hop is a real, live call (backed by `POST /api/step/<login|mint|exchange>`;
+`POST /api/run` runs all three at once). Everything runs server-side (no browser
+CORS) across three hops:
 
 1. **Requesting App — user sign-in** — OIDC password grant against Keycloak
    (`cncf-demo` realm, `requesting-app`) for the demo user `user`.

--- a/demos/cncf-stack/README.md
+++ b/demos/cncf-stack/README.md
@@ -1,0 +1,90 @@
+# CNCF Demo Stack
+
+Docker Compose stack for the CNCF conference demo of the AGNTCY Identity Service.
+
+## Services
+
+| Service             | Image                                | Host port(s)        | Purpose                                  |
+| ------------------- | ------------------------------------ | ------------------- | ---------------------------------------- |
+| `keycloak`          | `quay.io/keycloak/keycloak:26.7`     | `8080`              | OIDC provider + ID-JAG receiver          |
+| `gitea`             | `gitea/gitea:1.22`                   | `3000` (HTTP), `2222` (SSH) | Self-hosted git hosting          |
+| `identity-postgres` | `postgres:16`                        | _(internal)_        | Database for the identity node           |
+| `identity-vault`    | `hashicorp/vault:1.17`               | _(internal)_        | Key material storage (Vault dev mode)    |
+| `identity-node`     | `ghcr.io/agntcy/identity/node:0.0.23`| `4003` (REST), `4004` (gRPC) | AGNTCY identity node             |
+
+All image versions are pinned (no `latest`). All credentials are supplied via
+environment variables — none are hardcoded in `docker-compose.yaml`.
+
+## Quick start
+
+```bash
+cd demos/cncf-stack
+cp .env.example .env      # then edit .env and change the change-me-* values
+docker compose up -d
+```
+
+Check status:
+
+```bash
+docker compose ps
+```
+
+## Default URLs
+
+- Keycloak admin console: <http://localhost:8080> (user/password from `.env`)
+- Gitea: <http://localhost:3000>
+- Identity node REST API: <http://localhost:4003>
+- Identity node gRPC: `localhost:4004`
+
+## Configuration
+
+Copy `.env.example` to `.env` and adjust. Required values (no default; the stack
+will refuse to start without them) include the Keycloak admin password, the
+Postgres password, the Vault dev root token, and the identity node crypto key.
+
+> The values in `.env.example` are **local demo placeholders only**. Never reuse
+> them in any shared or production environment.
+
+## Cross-App Access (ID-JAG) & Token Exchange
+
+Keycloak is started with two **experimental** feature flags (see the
+[ID-JAG guide](https://www.keycloak.org/securing-apps/identity-assertion-jwt-authorization-grant)):
+
+```
+start-dev --features=identity-assertion-jwt,token-exchange-delegation
+```
+
+- `identity-assertion-jwt` — enables **ID-JAG** (Identity Assertion JWT
+  Authorization Grant / Cross-App Access). Requires **Keycloak 26.7+**.
+- `token-exchange-delegation` — enables the experimental delegation scope for
+  RFC 8693 token exchange (standard token exchange itself is enabled per-client
+  and needs no server flag on 26.x).
+
+> **Limitation:** Keycloak currently implements only the **Receiver** side of
+> ID-JAG — it accepts an externally-signed assertion at its token endpoint and
+> issues a local access token. It cannot yet **issue** ID-JAG assertions, so a
+> full end-to-end flow with Keycloak on both ends is not possible today. These
+> features are experimental and not for production.
+
+## Notes
+
+- Keycloak runs in `start-dev` mode (in-memory H2) — suitable for demos only.
+- Vault runs in dev mode; its data is not persisted across restarts.
+- Gitea and Postgres persist data via named volumes (`gitea-data`,
+  `identity-postgres-data`).
+- The identity node expects a Keycloak realm/client (`cncf-demo`) to be
+  provisioned. Realm bootstrap and the Envoy + `ext_authz` layer are tracked
+  separately in [#228](https://github.com/agntcy/identity-service/issues/228).
+
+## Tear down
+
+```bash
+docker compose down          # stop and remove containers
+docker compose down -v       # also remove named volumes (wipes data)
+```
+
+## Related issues
+
+- Create the docker-compose file: [#227](https://github.com/agntcy/identity-service/issues/227)
+- Envoy + ext_authz setup: [#228](https://github.com/agntcy/identity-service/issues/228)
+- Move `agenticidentity-cncf` here: [#229](https://github.com/agntcy/identity-service/issues/229)

--- a/demos/cncf-stack/README.md
+++ b/demos/cncf-stack/README.md
@@ -31,6 +31,236 @@ Check status:
 docker compose ps
 ```
 
+## Stack definition
+
+The canonical definition lives in
+[`docker-compose.yaml`](./docker-compose.yaml). It is reproduced here for
+reference (the file is the source of truth — if the two ever diverge, trust the
+file):
+
+<details>
+<summary>Full <code>docker-compose.yaml</code></summary>
+
+```yaml
+name: cncf-stack
+
+# CNCF conference demo stack for AGNTCY Identity Service.
+#
+# Services:
+#   - keycloak          OIDC provider + ID-JAG (Cross-App Access) receiver
+#   - idjag-issuer      mints ID-JAG assertions (stand-in enterprise IdP)
+#   - gitea             self-hosted git hosting
+#   - identity-postgres Postgres DB backing the AGNTCY identity node
+#   - identity-vault    Vault (dev mode) for the identity node key material
+#   - identity-node     AGNTCY identity node (REST + gRPC)
+#   - webapp            ID-JAG Cross-App Access demo UI
+#
+# All credentials are provided via environment variables (see .env.example).
+# Copy .env.example to .env and adjust before running:
+#   cp .env.example .env
+#   docker compose up -d
+
+services:
+  # ---------------------------------------------------------------------------
+  # Keycloak — OIDC provider
+  # ---------------------------------------------------------------------------
+  keycloak:
+    image: quay.io/keycloak/keycloak:26.7
+    container_name: cncf-keycloak
+    # ID-JAG (Cross-App Access) receiver + token exchange delegation are
+    # experimental features and must be enabled explicitly. Requires Keycloak
+    # 26.7+. See:
+    # https://www.keycloak.org/securing-apps/identity-assertion-jwt-authorization-grant
+    command: start-dev --import-realm --features=identity-assertion-jwt,token-exchange-delegation,parameterized-scopes
+    environment:
+      KC_BOOTSTRAP_ADMIN_USERNAME: ${KEYCLOAK_ADMIN:-admin}
+      KC_BOOTSTRAP_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD:?set KEYCLOAK_ADMIN_PASSWORD in .env}
+      KC_HTTP_PORT: 8080
+    ports:
+      - "${KEYCLOAK_HTTP_PORT:-8080}:8080"
+    volumes:
+      # Realm config imported on startup (see ./keycloak/cncf-demo-realm.json).
+      - ./keycloak:/opt/keycloak/data/import:ro
+    networks:
+      - cncf-net
+    healthcheck:
+      test: ["CMD-SHELL", "exec 3<>/dev/tcp/127.0.0.1/8080 && echo OK || exit 1"]
+      interval: 5s
+      timeout: 3s
+      retries: 30
+      start_period: 20s
+
+  # ---------------------------------------------------------------------------
+  # ID-JAG issuer — mints Identity Assertion JWTs (stands in for the central
+  # enterprise IdP, since Keycloak can only *receive* ID-JAG today).
+  # ---------------------------------------------------------------------------
+  idjag-issuer:
+    build: ./idjag-issuer
+    container_name: cncf-idjag-issuer
+    environment:
+      ISSUER_URL: http://idjag-issuer:9000
+    networks:
+      - cncf-net
+    healthcheck:
+      test: ["CMD-SHELL", "python -c \"import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:9000/healthz').status==200 else 1)\""]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 5s
+
+  # ---------------------------------------------------------------------------
+  # Gitea — self-hosted git hosting
+  # ---------------------------------------------------------------------------
+  gitea:
+    image: gitea/gitea:1.22
+    container_name: cncf-gitea
+    environment:
+      USER_UID: "1000"
+      USER_GID: "1000"
+      GITEA__database__DB_TYPE: sqlite3
+      GITEA__server__ROOT_URL: ${GITEA_ROOT_URL:-http://localhost:3000/}
+      GITEA__server__SSH_PORT: ${GITEA_SSH_PORT:-2222}
+      GITEA__security__INSTALL_LOCK: "true"
+      GITEA__service__DISABLE_REGISTRATION: "true"
+    ports:
+      - "${GITEA_HTTP_PORT:-3000}:3000"
+      - "${GITEA_SSH_PORT:-2222}:22"
+    volumes:
+      - gitea-data:/data
+    networks:
+      - cncf-net
+    healthcheck:
+      test: ["CMD-SHELL", "wget --spider -q http://127.0.0.1:3000/api/healthz || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 20
+      start_period: 15s
+
+  # ---------------------------------------------------------------------------
+  # Postgres — AGNTCY identity node DB
+  # ---------------------------------------------------------------------------
+  identity-postgres:
+    image: postgres:16
+    container_name: cncf-identity-postgres
+    environment:
+      POSTGRES_USER: ${DB_USERNAME:-postgres}
+      POSTGRES_PASSWORD: ${DB_PASSWORD:?set DB_PASSWORD in .env}
+      POSTGRES_DB: ${DB_NAME:-identity}
+    volumes:
+      - identity-postgres-data:/var/lib/postgresql/data
+    networks:
+      - cncf-net
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USERNAME:-postgres}"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+  # ---------------------------------------------------------------------------
+  # Vault (dev mode) — AGNTCY identity node key storage
+  # ---------------------------------------------------------------------------
+  identity-vault:
+    image: hashicorp/vault:1.17
+    container_name: cncf-identity-vault
+    environment:
+      VAULT_DEV_ROOT_TOKEN_ID: ${VAULT_DEV_ROOT_TOKEN:?set VAULT_DEV_ROOT_TOKEN in .env}
+      VAULT_DEV_LISTEN_ADDRESS: 0.0.0.0:8200
+    cap_add:
+      - IPC_LOCK
+    networks:
+      - cncf-net
+    healthcheck:
+      test: ["CMD-SHELL", "vault status -address=http://127.0.0.1:8200 || exit 1"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+  # ---------------------------------------------------------------------------
+  # AGNTCY Identity Node
+  # ---------------------------------------------------------------------------
+  identity-node:
+    image: ghcr.io/agntcy/identity/node:0.0.23
+    container_name: cncf-identity-node
+    pull_policy: always
+    depends_on:
+      identity-postgres:
+        condition: service_healthy
+      identity-vault:
+        condition: service_healthy
+    ports:
+      - "${IDENTITY_NODE_REST_PORT:-4003}:4000"   # REST API
+      - "${IDENTITY_NODE_GRPC_PORT:-4004}:4001"   # gRPC
+    environment:
+      DB_HOST: identity-postgres
+      DB_PORT: 5432
+      DB_USERNAME: ${DB_USERNAME:-postgres}
+      DB_PASSWORD: ${DB_PASSWORD:?set DB_PASSWORD in .env}
+      POSTGRES_PASSWORD: ${DB_PASSWORD:?set DB_PASSWORD in .env}
+      POSTGRES_DB: ${DB_NAME:-identity}
+      VAULT_HOST: identity-vault
+      VAULT_DEV_ROOT_TOKEN: ${VAULT_DEV_ROOT_TOKEN:?set VAULT_DEV_ROOT_TOKEN in .env}
+      GO_ENV: development
+      IAM_ORGANIZATION: ${IAM_ORGANIZATION:-cncf-demo}
+      SECRETS_CRYPTO_KEY: ${SECRETS_CRYPTO_KEY:?set SECRETS_CRYPTO_KEY in .env}
+      # Keycloak OIDC issuer — realm is provisioned separately after startup.
+      IAM_ISSUER: ${IAM_ISSUER:-http://keycloak:8080/realms/cncf-demo}
+      IAM_USER_CID: ${IAM_USER_CID:-requesting-app}
+      IAM_USER_CID_CLAIM_NAME: azp
+    networks:
+      - cncf-net
+    healthcheck:
+      # The node image has no HTTP health endpoint; verify the REST (4000) and
+      # gRPC (4001) ports are accepting connections instead.
+      test: ["CMD-SHELL", "nc -z 127.0.0.1 4000 && nc -z 127.0.0.1 4001 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 20
+      start_period: 20s
+
+  # ---------------------------------------------------------------------------
+  # Web app — drives the ID-JAG (Cross-App Access) sequence end to end
+  # ---------------------------------------------------------------------------
+  webapp:
+    build: ./webapp
+    container_name: cncf-webapp
+    depends_on:
+      keycloak:
+        condition: service_healthy
+      idjag-issuer:
+        condition: service_healthy
+    ports:
+      - "${WEBAPP_PORT:-8000}:8000"
+    environment:
+      KEYCLOAK_URL: http://keycloak:8080
+      KEYCLOAK_REALM: cncf-demo
+      USER_CLIENT_ID: requesting-app
+      USER_CLIENT_SECRET: ${CNCF_REQUESTING_SECRET:-demo-requesting-secret-change-me}
+      BACKEND_CLIENT_ID: receiving-app
+      BACKEND_CLIENT_SECRET: ${CNCF_RECEIVING_SECRET:-demo-receiving-secret-change-me}
+      DEMO_USER: ${CNCF_DEMO_USER:-user}
+      DEMO_PASSWORD: ${CNCF_DEMO_PASSWORD:-demo-password-change-me}
+      IDJAG_SUBJECT: ${CNCF_IDJAG_SUBJECT:-user@example.com}
+      IDJAG_ISSUER_URL: http://idjag-issuer:9000
+    networks:
+      - cncf-net
+    healthcheck:
+      test: ["CMD-SHELL", "python -c \"import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:8000/api/health').status==200 else 1)\""]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 5s
+
+networks:
+  cncf-net:
+    driver: bridge
+
+volumes:
+  gitea-data:
+  identity-postgres-data:
+```
+
+</details>
+
 ## Default URLs
 
 - **ID-JAG demo web app: <http://localhost:8000>**

--- a/demos/cncf-stack/README.md
+++ b/demos/cncf-stack/README.md
@@ -11,6 +11,8 @@ Docker Compose stack for the CNCF conference demo of the AGNTCY Identity Service
 | `identity-postgres` | `postgres:16`                        | _(internal)_        | Database for the identity node           |
 | `identity-vault`    | `hashicorp/vault:1.17`               | _(internal)_        | Key material storage (Vault dev mode)    |
 | `identity-node`     | `ghcr.io/agntcy/identity/node:0.0.23`| `4003` (REST), `4004` (gRPC) | AGNTCY identity node             |
+| `idjag-issuer`      | built from `./idjag-issuer`          | _(internal)_        | Mints ID-JAG assertions (stand-in issuer) |
+| `webapp`            | built from `./webapp`                | `8000`              | ID-JAG Cross-App Access demo UI          |
 
 All image versions are pinned (no `latest`). All credentials are supplied via
 environment variables — none are hardcoded in `docker-compose.yaml`.
@@ -31,10 +33,38 @@ docker compose ps
 
 ## Default URLs
 
+- **ID-JAG demo web app: <http://localhost:8000>**
 - Keycloak admin console: <http://localhost:8080> (user/password from `.env`)
 - Gitea: <http://localhost:3000>
 - Identity node REST API: <http://localhost:4003>
 - Identity node gRPC: `localhost:4004`
+
+## Testing the ID-JAG (Cross-App Access) sequence
+
+Open the web app at <http://localhost:8000> and click **Run ID-JAG sequence**.
+Everything runs server-side (no browser CORS) across three hops:
+
+1. **User login** — OIDC password grant against Keycloak (`cncf-demo` realm,
+   `cncf-demo-client`) for the demo user `sarah`.
+2. **Mint ID-JAG** — the `idjag-issuer` service signs an Identity Assertion JWT
+   (`iss` = issuer, `sub` = `sarah@enterprisex.com`, `aud` = the realm issuer,
+   `client_id`/`azp` = `backend-client`).
+3. **Receiver exchange** — the assertion is presented to Keycloak's token
+   endpoint with `grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer` and
+   `client_id=backend-client`; Keycloak validates it against the `id-jag`
+   identity provider (JWKS from the issuer), maps `sub` to the local user via
+   its federated identity link, and returns a **local access token**.
+
+The UI shows the decoded header + claims for each token.
+
+### Why the separate issuer?
+
+Keycloak 26.7 only implements the **Receiver** side of ID-JAG — it cannot mint
+assertions yet. The small `idjag-issuer` service stands in for the central
+enterprise IdP so the full flow is self-contained and testable locally. Swap it
+for a real issuer by editing the `id-jag` identity provider config in
+`keycloak/cncf-demo-realm.json` (issuer / JWKS URLs) and the matching federated
+identity link on the user.
 
 ## Configuration
 

--- a/demos/cncf-stack/README.md
+++ b/demos/cncf-stack/README.md
@@ -7,12 +7,15 @@ Docker Compose stack for the CNCF conference demo of the AGNTCY Identity Service
 | Service             | Image                                | Host port(s)        | Purpose                                  |
 | ------------------- | ------------------------------------ | ------------------- | ---------------------------------------- |
 | `keycloak`          | `quay.io/keycloak/keycloak:26.7`     | `8080`              | OIDC provider + ID-JAG receiver          |
-| `gitea`             | `gitea/gitea:1.22`                   | `3000` (HTTP), `2222` (SSH) | Self-hosted git hosting          |
+| `kc-init`           | `quay.io/keycloak/keycloak:26.7`     | _(one-shot)_        | Registers the `gitea:read`/`gitea:write` scopes |
+| `gitea`             | `gitea/gitea:1.22`                   | `3000` (HTTP), `2222` (SSH) | Self-hosted git hosting (the protected resource) |
+| `gitea-init`        | `gitea/gitea:1.22`                   | _(one-shot)_        | Seeds the Gitea admin + demo repos       |
+| `gitea-gateway`     | built from `./gitea-gateway`         | `9100`              | Enforces the narrow ID-JAG scope in front of Gitea |
 | `identity-postgres` | `postgres:16`                        | _(internal)_        | Database for the identity node           |
 | `identity-vault`    | `hashicorp/vault:1.17`               | _(internal)_        | Key material storage (Vault dev mode)    |
 | `identity-node`     | `ghcr.io/agntcy/identity/node:0.0.23`| `4003` (REST), `4004` (gRPC) | AGNTCY identity node             |
 | `idjag-issuer`      | built from `./idjag-issuer`          | _(internal)_        | Mints ID-JAG assertions (stand-in issuer) |
-| `webapp`            | built from `./webapp`                | `8000`              | ID-JAG Cross-App Access demo UI          |
+| `webapp`            | built from `./webapp`                | `8000`              | ID-JAG Cross-App Access + narrow-scoping demo UI |
 
 All image versions are pinned (no `latest`). All credentials are supplied via
 environment variables — none are hardcoded in `docker-compose.yaml`.
@@ -48,8 +51,11 @@ name: cncf-stack
 #
 # Services:
 #   - keycloak          OIDC provider + ID-JAG (Cross-App Access) receiver
+#   - kc-init           registers the gitea:read/gitea:write scopes (one-shot)
 #   - idjag-issuer      mints ID-JAG assertions (stand-in enterprise IdP)
-#   - gitea             self-hosted git hosting
+#   - gitea             self-hosted git hosting (the protected resource)
+#   - gitea-init        seeds the Gitea admin + demo repos (one-shot)
+#   - gitea-gateway     enforces the narrow ID-JAG scope in front of Gitea
 #   - identity-postgres Postgres DB backing the AGNTCY identity node
 #   - identity-vault    Vault (dev mode) for the identity node key material
 #   - identity-node     AGNTCY identity node (REST + gRPC)
@@ -89,6 +95,29 @@ services:
       timeout: 3s
       retries: 30
       start_period: 20s
+
+  # ---------------------------------------------------------------------------
+  # kc-init — registers the narrow gitea:read / gitea:write client scopes and
+  # assigns them (optional) to the Receiving App. One-shot; safe to re-run.
+  # ---------------------------------------------------------------------------
+  kc-init:
+    image: quay.io/keycloak/keycloak:26.7
+    container_name: cncf-kc-init
+    depends_on:
+      keycloak:
+        condition: service_healthy
+    entrypoint: ["bash", "/bootstrap-scopes.sh"]
+    environment:
+      KC_URL: http://keycloak:8080
+      KC_REALM: cncf-demo
+      KC_ADMIN: ${KEYCLOAK_ADMIN:-admin}
+      KC_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD:?set KEYCLOAK_ADMIN_PASSWORD in .env}
+      RECEIVER_CLIENT: receiving-app
+    volumes:
+      - ./keycloak/bootstrap-scopes.sh:/bootstrap-scopes.sh:ro
+    networks:
+      - cncf-net
+    restart: "no"
 
   # ---------------------------------------------------------------------------
   # ID-JAG issuer — mints Identity Assertion JWTs (stands in for the central
@@ -135,6 +164,62 @@ services:
       timeout: 5s
       retries: 20
       start_period: 15s
+
+  # ---------------------------------------------------------------------------
+  # gitea-init — creates the Gitea admin user and seeds demo repos. One-shot.
+  # ---------------------------------------------------------------------------
+  gitea-init:
+    image: gitea/gitea:1.22
+    container_name: cncf-gitea-init
+    depends_on:
+      gitea:
+        condition: service_healthy
+    entrypoint: ["sh", "/init.sh"]
+    user: git
+    environment:
+      GITEA_INTERNAL_URL: http://gitea:3000
+      GITEA_ADMIN_USER: ${GITEA_ADMIN_USER:-demo-admin}
+      GITEA_ADMIN_PASSWORD: ${GITEA_ADMIN_PASSWORD:?set GITEA_ADMIN_PASSWORD in .env}
+      GITEA_ADMIN_EMAIL: ${GITEA_ADMIN_EMAIL:-admin@example.com}
+      GITEA_WORK_DIR: /data
+    volumes:
+      - gitea-data:/data
+      - ./gitea/init.sh:/init.sh:ro
+    networks:
+      - cncf-net
+    restart: "no"
+
+  # ---------------------------------------------------------------------------
+  # gitea-gateway — validates the Receiving App's access token and enforces the
+  # narrow ID-JAG scope (gitea:read to list, gitea:write to create) before
+  # proxying to Gitea. This is where narrow scoping is actually applied.
+  # ---------------------------------------------------------------------------
+  gitea-gateway:
+    build: ./gitea-gateway
+    container_name: cncf-gitea-gateway
+    depends_on:
+      keycloak:
+        condition: service_healthy
+      gitea:
+        condition: service_healthy
+    ports:
+      - "${GITEA_GATEWAY_PORT:-9100}:9100"
+    environment:
+      KEYCLOAK_URL: http://keycloak:8080
+      KEYCLOAK_REALM: cncf-demo
+      GITEA_URL: http://gitea:3000
+      GITEA_ADMIN_USER: ${GITEA_ADMIN_USER:-demo-admin}
+      GITEA_ADMIN_PASSWORD: ${GITEA_ADMIN_PASSWORD:?set GITEA_ADMIN_PASSWORD in .env}
+      GITEA_READ_SCOPE: gitea:read
+      GITEA_WRITE_SCOPE: gitea:write
+    networks:
+      - cncf-net
+    healthcheck:
+      test: ["CMD-SHELL", "python -c \"import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:9100/healthz').status==200 else 1)\""]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 5s
 
   # ---------------------------------------------------------------------------
   # Postgres — AGNTCY identity node DB
@@ -228,6 +313,8 @@ services:
         condition: service_healthy
       idjag-issuer:
         condition: service_healthy
+      gitea-gateway:
+        condition: service_healthy
     ports:
       - "${WEBAPP_PORT:-8000}:8000"
     environment:
@@ -241,6 +328,7 @@ services:
       DEMO_PASSWORD: ${CNCF_DEMO_PASSWORD:-demo-password-change-me}
       IDJAG_SUBJECT: ${CNCF_IDJAG_SUBJECT:-user@example.com}
       IDJAG_ISSUER_URL: http://idjag-issuer:9000
+      GITEA_GATEWAY_URL: http://gitea-gateway:9100
     networks:
       - cncf-net
     healthcheck:
@@ -266,6 +354,7 @@ volumes:
 - **ID-JAG demo web app: <http://localhost:8000>**
 - Keycloak admin console: <http://localhost:8080> (user/password from `.env`)
 - Gitea: <http://localhost:3000>
+- Gitea gateway (scope-enforcing proxy): <http://localhost:9100>
 - Identity node REST API: <http://localhost:4003>
 - Identity node gRPC: `localhost:4004`
 
@@ -273,35 +362,74 @@ volumes:
 
 Open the web app at <http://localhost:8000>. The demo shows the **Requesting
 App** obtaining access to the **Receiving App** on behalf of the signed-in
-user. Two playback modes are available:
+user, and the Receiving App then calling **Gitea** with the exchanged token.
 
-- **Run (animated)** — plays all three hops automatically with a short pause
+At the top of the page a **scope selector** chooses what the ID-JAG assertion
+requests: read-only (`gitea:read`) or read + write (`gitea:read gitea:write`).
+Two playback modes are available:
+
+- **Run (animated)** — plays all hops automatically with a short pause
   between each, highlighting the sequence diagram as it goes.
 - **Next step** — executes one hop per click, so you can narrate each step
   during a presentation.
 
-Each hop is a real, live call (backed by `POST /api/step/<login|mint|exchange>`;
-`POST /api/run` runs all three at once). Everything runs server-side (no browser
-CORS) across three hops:
+Each hop is a real, live call (backed by
+`POST /api/step/<login|mint|exchange|gitea-list|gitea-create>`; `POST /api/run`
+runs the whole sequence at once). Everything runs server-side (no browser CORS):
 
 1. **Requesting App — user sign-in** — OIDC password grant against Keycloak
    (`cncf-demo` realm, `requesting-app`) for the demo user `user`.
 2. **Mint ID-JAG** — the `idjag-issuer` service signs an Identity Assertion JWT
    (`iss` = issuer, `sub` = `user@example.com`, `aud` = the realm issuer,
-   `client_id`/`azp` = `receiving-app`). It also carries an **actor** claim
-   (`act`) identifying the Requesting App acting on the user's behalf.
+   `client_id`/`azp` = `receiving-app`, `scope` = the requested scope). It also
+   carries an **actor** claim (`act`) identifying the Requesting App acting on
+   the user's behalf.
 3. **Receiving App — exchange** — the assertion is presented to Keycloak's token
    endpoint with `grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer` and
    `client_id=receiving-app`; Keycloak validates it against the `id-jag`
    identity provider (JWKS from the issuer), maps `sub` to the local user via
-   its federated identity link, and returns a **local access token**.
+   its federated identity link, and returns a **downscoped local access token**
+   whose `scope` reflects the requested `gitea:*` scope(s).
+4. **Read Gitea** — the Receiving App calls `GET /api/gitea/repos` on the
+   `gitea-gateway` with the access token. The gateway verifies the token and
+   requires `gitea:read`, then lists repositories from Gitea.
+5. **Write Gitea** — the Receiving App calls `POST /api/gitea/repos`. The
+   gateway requires `gitea:write`. **With a read-only scope this is refused
+   (HTTP 403)** — the narrow-scoping payoff — while a read + write token
+   creates the repo.
 
 > **Subject vs. actor:** the ID-JAG assertion carries both the `sub` (the end
 > user) and the `act` (actor = Requesting App) claims. Keycloak's ID-JAG
 > receiver maps `sub` to the local user but does **not** propagate the `act`
 > claim into the access token it issues today.
 
-The UI shows the decoded header + claims for each token.
+The UI shows the decoded header + claims for each token, and the gateway's JSON
+response for the Gitea hops.
+
+### Narrow scoping with Gitea
+
+Gitea is the demo's **protected resource**, fronted by the `gitea-gateway`. The
+gateway is a small OAuth resource server: it verifies the Receiving App's access
+token (RS256 signature via Keycloak's JWKS, issuer, expiry) and enforces the
+scope required for each operation before proxying to Gitea with a server-side
+admin credential the caller never sees:
+
+| Operation | Endpoint | Required scope |
+| --- | --- | --- |
+| List repositories | `GET /api/gitea/repos` | `gitea:read` |
+| Create a repository | `POST /api/gitea/repos` | `gitea:write` |
+
+Because the ID-JAG assertion only requests the scope the task needs, the token
+Keycloak issues is **downscoped**. A read-only assertion yields a token that can
+list repos but is rejected by the gateway when it attempts a write — least
+privilege enforced end to end, without the Receiving App ever holding broad
+Gitea credentials.
+
+The `gitea:read` / `gitea:write` client scopes are registered in the realm by
+the one-shot `kc-init` service (via `keycloak/bootstrap-scopes.sh`) and assigned
+as **optional** scopes on `receiving-app`, so they are only granted when
+explicitly requested. The demo repos are seeded by `gitea-init`
+(`gitea/init.sh`).
 
 ### Why the separate issuer?
 
@@ -334,6 +462,7 @@ automatically on startup (`start-dev --import-realm`, mounted at
 | Client | `receiving-app` | **Receiving App (ID-JAG receiver)** — exchanges an incoming assertion (`jwt-bearer` grant) for a local access token (`oauth2.jwt.authorization.grant.*`). |
 | Identity provider | `id-jag` | External ID-JAG issuer (OIDC), `jwtAuthorizationGrantEnabled=true`. Issuer URLs are **placeholders** — point them at your real IdP. |
 | Users | `user` | Demo user (`user@example.com`), federated to the `id-jag` issuer. |
+| Client scopes | `gitea:read`, `gitea:write` | Narrow Gitea scopes registered by `kc-init` and assigned as **optional** scopes on `receiving-app`. |
 
 > **Demo credentials only.** The client secrets and user passwords in the realm
 > file are obvious `*-change-me` placeholders for local use. Change them (and the
@@ -374,15 +503,17 @@ the web UI.
 ### Unit tests (pytest)
 
 Each Python service has its own tests. They mock all outbound calls, so no
-running stack is required. The two services both define a top-level `app`
-module, so run them in **separate** invocations:
+running stack is required. The services each define a top-level `app` module, so
+run them in **separate** invocations:
 
 ```bash
 python3 -m venv .venv
-./.venv/bin/pip install -r idjag-issuer/requirements-dev.txt -r webapp/requirements-dev.txt
+./.venv/bin/pip install -r idjag-issuer/requirements-dev.txt \
+  -r webapp/requirements-dev.txt -r gitea-gateway/requirements-dev.txt
 
-./.venv/bin/python -m pytest idjag-issuer/tests -q   # ID-JAG issuer: JWKS, discovery, /mint contract
-./.venv/bin/python -m pytest webapp/tests -q         # web app: /api/config + 3-hop /api/run (respx-mocked)
+./.venv/bin/python -m pytest idjag-issuer/tests -q    # ID-JAG issuer: JWKS, discovery, /mint contract
+./.venv/bin/python -m pytest webapp/tests -q          # web app: /api/config + full /api/run (respx-mocked)
+./.venv/bin/python -m pytest gitea-gateway/tests -q   # gateway: token verify + scope enforcement
 ```
 
 ### E2E tests (Playwright)
@@ -397,15 +528,21 @@ npm run install-browsers          # one-time: downloads chromium
 WEBAPP_URL=http://localhost:8000 npm test   # omit WEBAPP_URL to use the default :18000
 ```
 
-The E2E suite verifies the logical app names render, the sequence diagram is
-shown, and the full ID-JAG sequence completes with all three hops green.
+The E2E suite verifies the logical app names render, the five-step sequence
+diagram is shown, that a **read-only** run lists repos but is **denied** the
+write (narrow scoping), and that a **read + write** run creates the repo.
 
 ## Notes
 
 - Keycloak runs in `start-dev` mode (in-memory H2) — suitable for demos only.
+- `kc-init` and `gitea-init` are **one-shot** containers: they run to completion
+  on `up`, are idempotent, and exit 0 (they show as `Exited (0)` in
+  `docker compose ps`).
 - Vault runs in dev mode; its data is not persisted across restarts.
 - Gitea and Postgres persist data via named volumes (`gitea-data`,
-  `identity-postgres-data`).
+  `identity-postgres-data`). Because Gitea's admin/repos live in `gitea-data`,
+  `gitea-init` skips work that already exists; wipe the volume
+  (`docker compose down -v`) to re-seed from scratch.
 - The identity node expects a Keycloak realm/client (`cncf-demo`) to be
   provisioned. Realm bootstrap and the Envoy + `ext_authz` layer are tracked
   separately in [#228](https://github.com/agntcy/identity-service/issues/228).

--- a/demos/cncf-stack/README.md
+++ b/demos/cncf-stack/README.md
@@ -50,12 +50,18 @@ across three hops:
    (`cncf-demo` realm, `requesting-app`) for the demo user `user`.
 2. **Mint ID-JAG** — the `idjag-issuer` service signs an Identity Assertion JWT
    (`iss` = issuer, `sub` = `user@example.com`, `aud` = the realm issuer,
-   `client_id`/`azp` = `receiving-app`).
+   `client_id`/`azp` = `receiving-app`). It also carries an **actor** claim
+   (`act`) identifying the Requesting App acting on the user's behalf.
 3. **Receiving App — exchange** — the assertion is presented to Keycloak's token
    endpoint with `grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer` and
    `client_id=receiving-app`; Keycloak validates it against the `id-jag`
    identity provider (JWKS from the issuer), maps `sub` to the local user via
    its federated identity link, and returns a **local access token**.
+
+> **Subject vs. actor:** the ID-JAG assertion carries both the `sub` (the end
+> user) and the `act` (actor = Requesting App) claims. Keycloak's ID-JAG
+> receiver maps `sub` to the local user but does **not** propagate the `act`
+> claim into the access token it issues today.
 
 The UI shows the decoded header + claims for each token.
 
@@ -121,6 +127,40 @@ start-dev --features=identity-assertion-jwt,token-exchange-delegation
 > issues a local access token. It cannot yet **issue** ID-JAG assertions, so a
 > full end-to-end flow with Keycloak on both ends is not possible today. These
 > features are experimental and not for production.
+
+## Running the tests
+
+The demo ships with unit tests (per service) and Playwright E2E tests that drive
+the web UI.
+
+### Unit tests (pytest)
+
+Each Python service has its own tests. They mock all outbound calls, so no
+running stack is required. The two services both define a top-level `app`
+module, so run them in **separate** invocations:
+
+```bash
+python3 -m venv .venv
+./.venv/bin/pip install -r idjag-issuer/requirements-dev.txt -r webapp/requirements-dev.txt
+
+./.venv/bin/python -m pytest idjag-issuer/tests -q   # ID-JAG issuer: JWKS, discovery, /mint contract
+./.venv/bin/python -m pytest webapp/tests -q         # web app: /api/config + 3-hop /api/run (respx-mocked)
+```
+
+### E2E tests (Playwright)
+
+These drive the real web UI against the **running** stack. Bring the stack up
+first (`docker compose up -d`), then:
+
+```bash
+cd e2e
+npm install
+npm run install-browsers          # one-time: downloads chromium
+WEBAPP_URL=http://localhost:8000 npm test   # omit WEBAPP_URL to use the default :18000
+```
+
+The E2E suite verifies the logical app names render, the sequence diagram is
+shown, and the full ID-JAG sequence completes with all three hops green.
 
 ## Notes
 

--- a/demos/cncf-stack/docker-compose.yaml
+++ b/demos/cncf-stack/docker-compose.yaml
@@ -3,11 +3,13 @@ name: cncf-stack
 # CNCF conference demo stack for AGNTCY Identity Service.
 #
 # Services:
-#   - keycloak          OIDC provider (identity provider for the identity node)
+#   - keycloak          OIDC provider + ID-JAG (Cross-App Access) receiver
+#   - idjag-issuer      mints ID-JAG assertions (stand-in enterprise IdP)
 #   - gitea             self-hosted git hosting
 #   - identity-postgres Postgres DB backing the AGNTCY identity node
 #   - identity-vault    Vault (dev mode) for the identity node key material
 #   - identity-node     AGNTCY identity node (REST + gRPC)
+#   - webapp            ID-JAG Cross-App Access demo UI
 #
 # All credentials are provided via environment variables (see .env.example).
 # Copy .env.example to .env and adjust before running:

--- a/demos/cncf-stack/docker-compose.yaml
+++ b/demos/cncf-stack/docker-compose.yaml
@@ -45,6 +45,24 @@ services:
       start_period: 20s
 
   # ---------------------------------------------------------------------------
+  # ID-JAG issuer — mints Identity Assertion JWTs (stands in for the central
+  # enterprise IdP, since Keycloak can only *receive* ID-JAG today).
+  # ---------------------------------------------------------------------------
+  idjag-issuer:
+    build: ./idjag-issuer
+    container_name: cncf-idjag-issuer
+    environment:
+      ISSUER_URL: http://idjag-issuer:9000
+    networks:
+      - cncf-net
+    healthcheck:
+      test: ["CMD-SHELL", "python -c \"import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:9000/healthz').status==200 else 1)\""]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 5s
+
+  # ---------------------------------------------------------------------------
   # Gitea — self-hosted git hosting
   # ---------------------------------------------------------------------------
   gitea:
@@ -152,6 +170,39 @@ services:
       timeout: 5s
       retries: 20
       start_period: 20s
+
+  # ---------------------------------------------------------------------------
+  # Web app — drives the ID-JAG (Cross-App Access) sequence end to end
+  # ---------------------------------------------------------------------------
+  webapp:
+    build: ./webapp
+    container_name: cncf-webapp
+    depends_on:
+      keycloak:
+        condition: service_healthy
+      idjag-issuer:
+        condition: service_healthy
+    ports:
+      - "${WEBAPP_PORT:-8000}:8000"
+    environment:
+      KEYCLOAK_URL: http://keycloak:8080
+      KEYCLOAK_REALM: cncf-demo
+      USER_CLIENT_ID: cncf-demo-client
+      USER_CLIENT_SECRET: ${CNCF_CLIENT_SECRET:-demo-client-secret-change-me}
+      BACKEND_CLIENT_ID: backend-client
+      BACKEND_CLIENT_SECRET: ${CNCF_BACKEND_SECRET:-demo-backend-secret-change-me}
+      DEMO_USER: ${CNCF_DEMO_USER:-sarah}
+      DEMO_PASSWORD: ${CNCF_DEMO_PASSWORD:-demo-password-change-me}
+      IDJAG_SUBJECT: ${CNCF_IDJAG_SUBJECT:-sarah@enterprisex.com}
+      IDJAG_ISSUER_URL: http://idjag-issuer:9000
+    networks:
+      - cncf-net
+    healthcheck:
+      test: ["CMD-SHELL", "python -c \"import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:8000/api/health').status==200 else 1)\""]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 5s
 
 networks:
   cncf-net:

--- a/demos/cncf-stack/docker-compose.yaml
+++ b/demos/cncf-stack/docker-compose.yaml
@@ -158,7 +158,7 @@ services:
       SECRETS_CRYPTO_KEY: ${SECRETS_CRYPTO_KEY:?set SECRETS_CRYPTO_KEY in .env}
       # Keycloak OIDC issuer — realm is provisioned separately after startup.
       IAM_ISSUER: ${IAM_ISSUER:-http://keycloak:8080/realms/cncf-demo}
-      IAM_USER_CID: ${IAM_USER_CID:-cncf-demo-client}
+      IAM_USER_CID: ${IAM_USER_CID:-requesting-app}
       IAM_USER_CID_CLAIM_NAME: azp
     networks:
       - cncf-net
@@ -187,13 +187,13 @@ services:
     environment:
       KEYCLOAK_URL: http://keycloak:8080
       KEYCLOAK_REALM: cncf-demo
-      USER_CLIENT_ID: cncf-demo-client
-      USER_CLIENT_SECRET: ${CNCF_CLIENT_SECRET:-demo-client-secret-change-me}
-      BACKEND_CLIENT_ID: backend-client
-      BACKEND_CLIENT_SECRET: ${CNCF_BACKEND_SECRET:-demo-backend-secret-change-me}
-      DEMO_USER: ${CNCF_DEMO_USER:-sarah}
+      USER_CLIENT_ID: requesting-app
+      USER_CLIENT_SECRET: ${CNCF_REQUESTING_SECRET:-demo-requesting-secret-change-me}
+      BACKEND_CLIENT_ID: receiving-app
+      BACKEND_CLIENT_SECRET: ${CNCF_RECEIVING_SECRET:-demo-receiving-secret-change-me}
+      DEMO_USER: ${CNCF_DEMO_USER:-user}
       DEMO_PASSWORD: ${CNCF_DEMO_PASSWORD:-demo-password-change-me}
-      IDJAG_SUBJECT: ${CNCF_IDJAG_SUBJECT:-sarah@enterprisex.com}
+      IDJAG_SUBJECT: ${CNCF_IDJAG_SUBJECT:-user@example.com}
       IDJAG_ISSUER_URL: http://idjag-issuer:9000
     networks:
       - cncf-net

--- a/demos/cncf-stack/docker-compose.yaml
+++ b/demos/cncf-stack/docker-compose.yaml
@@ -25,13 +25,16 @@ services:
     # experimental features and must be enabled explicitly. Requires Keycloak
     # 26.7+. See:
     # https://www.keycloak.org/securing-apps/identity-assertion-jwt-authorization-grant
-    command: start-dev --features=identity-assertion-jwt,token-exchange-delegation,parameterized-scopes
+    command: start-dev --import-realm --features=identity-assertion-jwt,token-exchange-delegation,parameterized-scopes
     environment:
       KC_BOOTSTRAP_ADMIN_USERNAME: ${KEYCLOAK_ADMIN:-admin}
       KC_BOOTSTRAP_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD:?set KEYCLOAK_ADMIN_PASSWORD in .env}
       KC_HTTP_PORT: 8080
     ports:
       - "${KEYCLOAK_HTTP_PORT:-8080}:8080"
+    volumes:
+      # Realm config imported on startup (see ./keycloak/cncf-demo-realm.json).
+      - ./keycloak:/opt/keycloak/data/import:ro
     networks:
       - cncf-net
     healthcheck:

--- a/demos/cncf-stack/docker-compose.yaml
+++ b/demos/cncf-stack/docker-compose.yaml
@@ -4,8 +4,11 @@ name: cncf-stack
 #
 # Services:
 #   - keycloak          OIDC provider + ID-JAG (Cross-App Access) receiver
+#   - kc-init           registers the gitea:read/gitea:write scopes (one-shot)
 #   - idjag-issuer      mints ID-JAG assertions (stand-in enterprise IdP)
-#   - gitea             self-hosted git hosting
+#   - gitea             self-hosted git hosting (the protected resource)
+#   - gitea-init        seeds the Gitea admin + demo repos (one-shot)
+#   - gitea-gateway     enforces the narrow ID-JAG scope in front of Gitea
 #   - identity-postgres Postgres DB backing the AGNTCY identity node
 #   - identity-vault    Vault (dev mode) for the identity node key material
 #   - identity-node     AGNTCY identity node (REST + gRPC)
@@ -45,6 +48,29 @@ services:
       timeout: 3s
       retries: 30
       start_period: 20s
+
+  # ---------------------------------------------------------------------------
+  # kc-init — registers the narrow gitea:read / gitea:write client scopes and
+  # assigns them (optional) to the Receiving App. One-shot; safe to re-run.
+  # ---------------------------------------------------------------------------
+  kc-init:
+    image: quay.io/keycloak/keycloak:26.7
+    container_name: cncf-kc-init
+    depends_on:
+      keycloak:
+        condition: service_healthy
+    entrypoint: ["bash", "/bootstrap-scopes.sh"]
+    environment:
+      KC_URL: http://keycloak:8080
+      KC_REALM: cncf-demo
+      KC_ADMIN: ${KEYCLOAK_ADMIN:-admin}
+      KC_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD:?set KEYCLOAK_ADMIN_PASSWORD in .env}
+      RECEIVER_CLIENT: receiving-app
+    volumes:
+      - ./keycloak/bootstrap-scopes.sh:/bootstrap-scopes.sh:ro
+    networks:
+      - cncf-net
+    restart: "no"
 
   # ---------------------------------------------------------------------------
   # ID-JAG issuer — mints Identity Assertion JWTs (stands in for the central
@@ -91,6 +117,62 @@ services:
       timeout: 5s
       retries: 20
       start_period: 15s
+
+  # ---------------------------------------------------------------------------
+  # gitea-init — creates the Gitea admin user and seeds demo repos. One-shot.
+  # ---------------------------------------------------------------------------
+  gitea-init:
+    image: gitea/gitea:1.22
+    container_name: cncf-gitea-init
+    depends_on:
+      gitea:
+        condition: service_healthy
+    entrypoint: ["sh", "/init.sh"]
+    user: git
+    environment:
+      GITEA_INTERNAL_URL: http://gitea:3000
+      GITEA_ADMIN_USER: ${GITEA_ADMIN_USER:-demo-admin}
+      GITEA_ADMIN_PASSWORD: ${GITEA_ADMIN_PASSWORD:?set GITEA_ADMIN_PASSWORD in .env}
+      GITEA_ADMIN_EMAIL: ${GITEA_ADMIN_EMAIL:-admin@example.com}
+      GITEA_WORK_DIR: /data
+    volumes:
+      - gitea-data:/data
+      - ./gitea/init.sh:/init.sh:ro
+    networks:
+      - cncf-net
+    restart: "no"
+
+  # ---------------------------------------------------------------------------
+  # gitea-gateway — validates the Receiving App's access token and enforces the
+  # narrow ID-JAG scope (gitea:read to list, gitea:write to create) before
+  # proxying to Gitea. This is where narrow scoping is actually applied.
+  # ---------------------------------------------------------------------------
+  gitea-gateway:
+    build: ./gitea-gateway
+    container_name: cncf-gitea-gateway
+    depends_on:
+      keycloak:
+        condition: service_healthy
+      gitea:
+        condition: service_healthy
+    ports:
+      - "${GITEA_GATEWAY_PORT:-9100}:9100"
+    environment:
+      KEYCLOAK_URL: http://keycloak:8080
+      KEYCLOAK_REALM: cncf-demo
+      GITEA_URL: http://gitea:3000
+      GITEA_ADMIN_USER: ${GITEA_ADMIN_USER:-demo-admin}
+      GITEA_ADMIN_PASSWORD: ${GITEA_ADMIN_PASSWORD:?set GITEA_ADMIN_PASSWORD in .env}
+      GITEA_READ_SCOPE: gitea:read
+      GITEA_WRITE_SCOPE: gitea:write
+    networks:
+      - cncf-net
+    healthcheck:
+      test: ["CMD-SHELL", "python -c \"import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:9100/healthz').status==200 else 1)\""]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 5s
 
   # ---------------------------------------------------------------------------
   # Postgres — AGNTCY identity node DB
@@ -184,6 +266,8 @@ services:
         condition: service_healthy
       idjag-issuer:
         condition: service_healthy
+      gitea-gateway:
+        condition: service_healthy
     ports:
       - "${WEBAPP_PORT:-8000}:8000"
     environment:
@@ -197,6 +281,7 @@ services:
       DEMO_PASSWORD: ${CNCF_DEMO_PASSWORD:-demo-password-change-me}
       IDJAG_SUBJECT: ${CNCF_IDJAG_SUBJECT:-user@example.com}
       IDJAG_ISSUER_URL: http://idjag-issuer:9000
+      GITEA_GATEWAY_URL: http://gitea-gateway:9100
     networks:
       - cncf-net
     healthcheck:

--- a/demos/cncf-stack/docker-compose.yaml
+++ b/demos/cncf-stack/docker-compose.yaml
@@ -1,0 +1,159 @@
+name: cncf-stack
+
+# CNCF conference demo stack for AGNTCY Identity Service.
+#
+# Services:
+#   - keycloak          OIDC provider (identity provider for the identity node)
+#   - gitea             self-hosted git hosting
+#   - identity-postgres Postgres DB backing the AGNTCY identity node
+#   - identity-vault    Vault (dev mode) for the identity node key material
+#   - identity-node     AGNTCY identity node (REST + gRPC)
+#
+# All credentials are provided via environment variables (see .env.example).
+# Copy .env.example to .env and adjust before running:
+#   cp .env.example .env
+#   docker compose up -d
+
+services:
+  # ---------------------------------------------------------------------------
+  # Keycloak — OIDC provider
+  # ---------------------------------------------------------------------------
+  keycloak:
+    image: quay.io/keycloak/keycloak:26.7
+    container_name: cncf-keycloak
+    # ID-JAG (Cross-App Access) receiver + token exchange delegation are
+    # experimental features and must be enabled explicitly. Requires Keycloak
+    # 26.7+. See:
+    # https://www.keycloak.org/securing-apps/identity-assertion-jwt-authorization-grant
+    command: start-dev --features=identity-assertion-jwt,token-exchange-delegation,parameterized-scopes
+    environment:
+      KC_BOOTSTRAP_ADMIN_USERNAME: ${KEYCLOAK_ADMIN:-admin}
+      KC_BOOTSTRAP_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD:?set KEYCLOAK_ADMIN_PASSWORD in .env}
+      KC_HTTP_PORT: 8080
+    ports:
+      - "${KEYCLOAK_HTTP_PORT:-8080}:8080"
+    networks:
+      - cncf-net
+    healthcheck:
+      test: ["CMD-SHELL", "exec 3<>/dev/tcp/127.0.0.1/8080 && echo OK || exit 1"]
+      interval: 5s
+      timeout: 3s
+      retries: 30
+      start_period: 20s
+
+  # ---------------------------------------------------------------------------
+  # Gitea — self-hosted git hosting
+  # ---------------------------------------------------------------------------
+  gitea:
+    image: gitea/gitea:1.22
+    container_name: cncf-gitea
+    environment:
+      USER_UID: "1000"
+      USER_GID: "1000"
+      GITEA__database__DB_TYPE: sqlite3
+      GITEA__server__ROOT_URL: ${GITEA_ROOT_URL:-http://localhost:3000/}
+      GITEA__server__SSH_PORT: ${GITEA_SSH_PORT:-2222}
+      GITEA__security__INSTALL_LOCK: "true"
+      GITEA__service__DISABLE_REGISTRATION: "true"
+    ports:
+      - "${GITEA_HTTP_PORT:-3000}:3000"
+      - "${GITEA_SSH_PORT:-2222}:22"
+    volumes:
+      - gitea-data:/data
+    networks:
+      - cncf-net
+    healthcheck:
+      test: ["CMD-SHELL", "wget --spider -q http://127.0.0.1:3000/api/healthz || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 20
+      start_period: 15s
+
+  # ---------------------------------------------------------------------------
+  # Postgres — AGNTCY identity node DB
+  # ---------------------------------------------------------------------------
+  identity-postgres:
+    image: postgres:16
+    container_name: cncf-identity-postgres
+    environment:
+      POSTGRES_USER: ${DB_USERNAME:-postgres}
+      POSTGRES_PASSWORD: ${DB_PASSWORD:?set DB_PASSWORD in .env}
+      POSTGRES_DB: ${DB_NAME:-identity}
+    volumes:
+      - identity-postgres-data:/var/lib/postgresql/data
+    networks:
+      - cncf-net
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USERNAME:-postgres}"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+  # ---------------------------------------------------------------------------
+  # Vault (dev mode) — AGNTCY identity node key storage
+  # ---------------------------------------------------------------------------
+  identity-vault:
+    image: hashicorp/vault:1.17
+    container_name: cncf-identity-vault
+    environment:
+      VAULT_DEV_ROOT_TOKEN_ID: ${VAULT_DEV_ROOT_TOKEN:?set VAULT_DEV_ROOT_TOKEN in .env}
+      VAULT_DEV_LISTEN_ADDRESS: 0.0.0.0:8200
+    cap_add:
+      - IPC_LOCK
+    networks:
+      - cncf-net
+    healthcheck:
+      test: ["CMD-SHELL", "vault status -address=http://127.0.0.1:8200 || exit 1"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+  # ---------------------------------------------------------------------------
+  # AGNTCY Identity Node
+  # ---------------------------------------------------------------------------
+  identity-node:
+    image: ghcr.io/agntcy/identity/node:0.0.23
+    container_name: cncf-identity-node
+    pull_policy: always
+    depends_on:
+      identity-postgres:
+        condition: service_healthy
+      identity-vault:
+        condition: service_healthy
+    ports:
+      - "${IDENTITY_NODE_REST_PORT:-4003}:4000"   # REST API
+      - "${IDENTITY_NODE_GRPC_PORT:-4004}:4001"   # gRPC
+    environment:
+      DB_HOST: identity-postgres
+      DB_PORT: 5432
+      DB_USERNAME: ${DB_USERNAME:-postgres}
+      DB_PASSWORD: ${DB_PASSWORD:?set DB_PASSWORD in .env}
+      POSTGRES_PASSWORD: ${DB_PASSWORD:?set DB_PASSWORD in .env}
+      POSTGRES_DB: ${DB_NAME:-identity}
+      VAULT_HOST: identity-vault
+      VAULT_DEV_ROOT_TOKEN: ${VAULT_DEV_ROOT_TOKEN:?set VAULT_DEV_ROOT_TOKEN in .env}
+      GO_ENV: development
+      IAM_ORGANIZATION: ${IAM_ORGANIZATION:-cncf-demo}
+      SECRETS_CRYPTO_KEY: ${SECRETS_CRYPTO_KEY:?set SECRETS_CRYPTO_KEY in .env}
+      # Keycloak OIDC issuer — realm is provisioned separately after startup.
+      IAM_ISSUER: ${IAM_ISSUER:-http://keycloak:8080/realms/cncf-demo}
+      IAM_USER_CID: ${IAM_USER_CID:-cncf-demo-client}
+      IAM_USER_CID_CLAIM_NAME: azp
+    networks:
+      - cncf-net
+    healthcheck:
+      # The node image has no HTTP health endpoint; verify the REST (4000) and
+      # gRPC (4001) ports are accepting connections instead.
+      test: ["CMD-SHELL", "nc -z 127.0.0.1 4000 && nc -z 127.0.0.1 4001 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 20
+      start_period: 20s
+
+networks:
+  cncf-net:
+    driver: bridge
+
+volumes:
+  gitea-data:
+  identity-postgres-data:

--- a/demos/cncf-stack/e2e/.gitignore
+++ b/demos/cncf-stack/e2e/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+test-results/
+playwright-report/
+blob-report/
+.playwright/

--- a/demos/cncf-stack/e2e/package-lock.json
+++ b/demos/cncf-stack/e2e/package-lock.json
@@ -1,0 +1,78 @@
+{
+  "name": "cncf-stack-e2e",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "cncf-stack-e2e",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@playwright/test": "^1.48.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/demos/cncf-stack/e2e/package.json
+++ b/demos/cncf-stack/e2e/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "cncf-stack-e2e",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Playwright E2E tests for the CNCF ID-JAG demo web app.",
+  "scripts": {
+    "test": "playwright test",
+    "install-browsers": "playwright install chromium"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.48.0"
+  }
+}

--- a/demos/cncf-stack/e2e/playwright.config.ts
+++ b/demos/cncf-stack/e2e/playwright.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig, devices } from '@playwright/test';
+
+// The demo web app. Override for non-default ports, e.g.
+//   WEBAPP_URL=http://localhost:8000 npm test
+const baseURL = process.env.WEBAPP_URL || 'http://localhost:18000';
+
+export default defineConfig({
+  testDir: './tests',
+  timeout: 60_000,
+  expect: { timeout: 15_000 },
+  fullyParallel: true,
+  reporter: [['list']],
+  use: {
+    baseURL,
+    trace: 'on-first-retry',
+  },
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+});

--- a/demos/cncf-stack/e2e/tests/idjag.spec.ts
+++ b/demos/cncf-stack/e2e/tests/idjag.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from '@playwright/test';
+
+const STEPS = ['login', 'mint', 'exchange'] as const;
+
+test.describe('CNCF ID-JAG cross-app access demo', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+  });
+
+  test('renders the cross-app access UI with logical app names', async ({ page }) => {
+    await expect(page.locator('h1')).toContainText('Cross-App Access');
+    await expect(page.locator('h1')).toContainText('Requesting App');
+    await expect(page.locator('h1')).toContainText('Receiving App');
+
+    const config = page.locator('#config');
+    await expect(config).toContainText('requesting-app');
+    await expect(config).toContainText('receiving-app');
+    await expect(config).toContainText('user@example.com');
+  });
+
+  test('shows a sequence diagram with three message steps', async ({ page }) => {
+    await expect(page.locator('.diagram svg')).toBeVisible();
+    for (const id of STEPS) {
+      await expect(page.locator(`[data-step="${id}"]`)).toBeVisible();
+      // Before running, each step is in the pending state.
+      await expect(page.locator(`[data-step="${id}"]`)).toHaveClass(/pending/);
+    }
+    await expect(page.locator('.diagram')).toContainText('Mint ID-JAG');
+  });
+
+  test('runs the full ID-JAG sequence end to end', async ({ page }) => {
+    await page.locator('#run').click();
+
+    // All three step cards must reach the "ok" state.
+    await expect(page.locator('.badge.ok')).toHaveCount(3, { timeout: 30_000 });
+
+    // The sequence diagram reflects success for every hop.
+    for (const id of STEPS) {
+      await expect(page.locator(`[data-step="${id}"]`)).toHaveClass(/\bok\b/);
+    }
+
+    // Decoded tokens are shown, and the actor is the Requesting App.
+    const steps = page.locator('#steps');
+    await expect(steps.locator('pre').first()).toContainText('"sub"');
+    await expect(steps).toContainText('requesting-app');
+  });
+});

--- a/demos/cncf-stack/e2e/tests/idjag.spec.ts
+++ b/demos/cncf-stack/e2e/tests/idjag.spec.ts
@@ -1,8 +1,9 @@
 import { test, expect } from '@playwright/test';
 
-const STEPS = ['login', 'mint', 'exchange'] as const;
+const STEPS = ['login', 'mint', 'exchange', 'gitea-list', 'gitea-create'] as const;
+const READ_WRITE = 'input[name="scope"][value="openid gitea:read gitea:write"]';
 
-test.describe('CNCF ID-JAG cross-app access demo', () => {
+test.describe('CNCF ID-JAG cross-app access + Gitea narrow-scoping demo', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/');
   });
@@ -10,58 +11,72 @@ test.describe('CNCF ID-JAG cross-app access demo', () => {
   test('renders the cross-app access UI with logical app names', async ({ page }) => {
     await expect(page.locator('h1')).toContainText('Cross-App Access');
     await expect(page.locator('h1')).toContainText('Requesting App');
-    await expect(page.locator('h1')).toContainText('Receiving App');
+    await expect(page.locator('h1')).toContainText('Gitea');
 
     const config = page.locator('#config');
     await expect(config).toContainText('requesting-app');
     await expect(config).toContainText('receiving-app');
     await expect(config).toContainText('user@example.com');
+    await expect(config).toContainText('gitea-gateway');
+
+    // The scope selector defaults to read-only.
+    await expect(page.locator('input[name="scope"]:checked')).toHaveValue('openid gitea:read');
   });
 
-  test('shows a sequence diagram with three message steps', async ({ page }) => {
+  test('shows a sequence diagram with five message steps and Gitea', async ({ page }) => {
     await expect(page.locator('.diagram svg')).toBeVisible();
     for (const id of STEPS) {
       await expect(page.locator(`[data-step="${id}"]`)).toBeVisible();
-      // Before running, each step is in the pending state.
       await expect(page.locator(`[data-step="${id}"]`)).toHaveClass(/pending/);
     }
     await expect(page.locator('.diagram')).toContainText('Mint ID-JAG');
+    await expect(page.locator('.diagram')).toContainText('gitea:write');
   });
 
-  test('runs the full ID-JAG sequence end to end (animated)', async ({ page }) => {
+  test('read-only run: lists repos but is denied the write (narrow scoping)', async ({ page }) => {
     await page.locator('#run').click();
 
-    // All three step cards must reach the "ok" state.
-    await expect(page.locator('.badge.ok')).toHaveCount(3, { timeout: 30_000 });
+    // login + mint + exchange + gitea-list succeed; gitea-create is denied.
+    await expect(page.locator('.badge.ok')).toHaveCount(4, { timeout: 45_000 });
+    await expect(page.locator('.badge.denied')).toHaveCount(1, { timeout: 45_000 });
 
-    // The sequence diagram reflects success for every hop.
+    await expect(page.locator('[data-step="gitea-list"]')).toHaveClass(/\bok\b/);
+    await expect(page.locator('[data-step="gitea-create"]')).toHaveClass(/\bdenied\b/);
+
+    const steps = page.locator('#steps');
+    await expect(steps).toContainText('gitea:write');
+  });
+
+  test('read+write run: creates the repo', async ({ page }) => {
+    await page.locator(READ_WRITE).check();
+    await page.locator('#run').click();
+
+    await expect(page.locator('.badge.ok')).toHaveCount(5, { timeout: 45_000 });
     for (const id of STEPS) {
       await expect(page.locator(`[data-step="${id}"]`)).toHaveClass(/\bok\b/);
     }
-
-    // Decoded tokens are shown, and the actor is the Requesting App.
     const steps = page.locator('#steps');
-    await expect(steps.locator('pre').first()).toContainText('"sub"');
-    await expect(steps).toContainText('requesting-app');
+    await expect(steps).toContainText('created');
   });
 
-  test('steps through the sequence one hop at a time', async ({ page }) => {
+  test('steps through all five hops one at a time', async ({ page }) => {
     const step = page.locator('#step');
 
-    // Hop 1 — only the login card should be green.
-    await step.click();
-    await expect(page.locator('.badge.ok')).toHaveCount(1, { timeout: 15_000 });
+    await step.click(); // login
+    await expect(page.locator('.badge.ok')).toHaveCount(1, { timeout: 20_000 });
     await expect(page.locator('[data-step="login"]')).toHaveClass(/\bok\b/);
-    await expect(page.locator('[data-step="mint"]')).toHaveClass(/pending/);
 
-    // Hop 2 — mint.
-    await step.click();
-    await expect(page.locator('.badge.ok')).toHaveCount(2, { timeout: 15_000 });
-    await expect(page.locator('[data-step="mint"]')).toHaveClass(/\bok\b/);
+    await step.click(); // mint
+    await expect(page.locator('.badge.ok')).toHaveCount(2, { timeout: 20_000 });
 
-    // Hop 3 — exchange; the Next button becomes "Done".
-    await step.click();
-    await expect(page.locator('.badge.ok')).toHaveCount(3, { timeout: 15_000 });
+    await step.click(); // exchange
+    await expect(page.locator('.badge.ok')).toHaveCount(3, { timeout: 20_000 });
+
+    await step.click(); // gitea-list (read)
+    await expect(page.locator('[data-step="gitea-list"]')).toHaveClass(/\bok\b/, { timeout: 20_000 });
+
+    await step.click(); // gitea-create -> denied under read-only
+    await expect(page.locator('[data-step="gitea-create"]')).toHaveClass(/\bdenied\b/, { timeout: 20_000 });
     await expect(step).toBeDisabled();
     await expect(step).toHaveText(/Done/);
   });

--- a/demos/cncf-stack/e2e/tests/idjag.spec.ts
+++ b/demos/cncf-stack/e2e/tests/idjag.spec.ts
@@ -28,7 +28,7 @@ test.describe('CNCF ID-JAG cross-app access demo', () => {
     await expect(page.locator('.diagram')).toContainText('Mint ID-JAG');
   });
 
-  test('runs the full ID-JAG sequence end to end', async ({ page }) => {
+  test('runs the full ID-JAG sequence end to end (animated)', async ({ page }) => {
     await page.locator('#run').click();
 
     // All three step cards must reach the "ok" state.
@@ -43,5 +43,26 @@ test.describe('CNCF ID-JAG cross-app access demo', () => {
     const steps = page.locator('#steps');
     await expect(steps.locator('pre').first()).toContainText('"sub"');
     await expect(steps).toContainText('requesting-app');
+  });
+
+  test('steps through the sequence one hop at a time', async ({ page }) => {
+    const step = page.locator('#step');
+
+    // Hop 1 — only the login card should be green.
+    await step.click();
+    await expect(page.locator('.badge.ok')).toHaveCount(1, { timeout: 15_000 });
+    await expect(page.locator('[data-step="login"]')).toHaveClass(/\bok\b/);
+    await expect(page.locator('[data-step="mint"]')).toHaveClass(/pending/);
+
+    // Hop 2 — mint.
+    await step.click();
+    await expect(page.locator('.badge.ok')).toHaveCount(2, { timeout: 15_000 });
+    await expect(page.locator('[data-step="mint"]')).toHaveClass(/\bok\b/);
+
+    // Hop 3 — exchange; the Next button becomes "Done".
+    await step.click();
+    await expect(page.locator('.badge.ok')).toHaveCount(3, { timeout: 15_000 });
+    await expect(step).toBeDisabled();
+    await expect(step).toHaveText(/Done/);
   });
 });

--- a/demos/cncf-stack/e2e/tests/idjag.spec.ts
+++ b/demos/cncf-stack/e2e/tests/idjag.spec.ts
@@ -9,9 +9,9 @@ test.describe('CNCF ID-JAG cross-app access + Gitea narrow-scoping demo', () => 
   });
 
   test('renders the cross-app access UI with logical app names', async ({ page }) => {
-    await expect(page.locator('h1')).toContainText('Cross-App Access');
-    await expect(page.locator('h1')).toContainText('Requesting App');
-    await expect(page.locator('h1')).toContainText('Gitea');
+    await expect(page.locator('header')).toContainText('Cross-App Access');
+    await expect(page.locator('header')).toContainText('Requesting App');
+    await expect(page.locator('header')).toContainText('Gitea');
 
     const config = page.locator('#config');
     await expect(config).toContainText('requesting-app');
@@ -24,13 +24,37 @@ test.describe('CNCF ID-JAG cross-app access + Gitea narrow-scoping demo', () => 
   });
 
   test('shows a sequence diagram with five message steps and Gitea', async ({ page }) => {
-    await expect(page.locator('.diagram svg')).toBeVisible();
+    await expect(page.locator('#tab-demo .diagram svg')).toBeVisible();
     for (const id of STEPS) {
       await expect(page.locator(`[data-step="${id}"]`)).toBeVisible();
       await expect(page.locator(`[data-step="${id}"]`)).toHaveClass(/pending/);
     }
-    await expect(page.locator('.diagram')).toContainText('Mint ID-JAG');
-    await expect(page.locator('.diagram')).toContainText('gitea:write');
+    await expect(page.locator('#tab-demo .diagram')).toContainText('Mint ID-JAG');
+    await expect(page.locator('#tab-demo .diagram')).toContainText('gitea:write');
+  });
+
+  test('has a How it works tab explaining Keycloak config and VCs', async ({ page }) => {
+    // Demo tab is active by default; the how tab is hidden.
+    await expect(page.locator('#tab-how')).toBeHidden();
+
+    await page.getByRole('button', { name: 'How it works' }).click();
+
+    await expect(page.locator('#tab-how')).toBeVisible();
+    await expect(page.locator('#tab-demo')).toBeHidden();
+
+    const how = page.locator('#tab-how');
+    await expect(how).toContainText('identity-assertion-jwt');
+    await expect(how).toContainText('oauth2.jwt.authorization.grant.enabled');
+    await expect(how).toContainText('Verifiable Credentials');
+    await expect(how).toContainText('/vc/publish');
+    await expect(how).toContainText('VC-backed ID-JAG');
+    // Extra explainer sequence diagrams are present.
+    await expect(how.locator('.diagram.doc svg').first()).toBeVisible();
+
+    // Switching back restores the live demo.
+    await page.getByRole('button', { name: 'Live demo' }).click();
+    await expect(page.locator('#tab-demo')).toBeVisible();
+    await expect(page.locator('#tab-how')).toBeHidden();
   });
 
   test('read-only run: lists repos but is denied the write (narrow scoping)', async ({ page }) => {

--- a/demos/cncf-stack/gitea-gateway/Dockerfile
+++ b/demos/cncf-stack/gitea-gateway/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY app.py .
+
+ENV PYTHONUNBUFFERED=1
+EXPOSE 9100
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "9100"]

--- a/demos/cncf-stack/gitea-gateway/app.py
+++ b/demos/cncf-stack/gitea-gateway/app.py
@@ -1,0 +1,143 @@
+"""Gitea gateway — enforces ID-JAG narrow scoping in front of Gitea.
+
+The Receiving App presents the access token it obtained from Keycloak's ID-JAG
+(jwt-bearer) exchange. This gateway:
+
+  1. verifies the token (RS256 signature via Keycloak JWKS, issuer, expiry),
+  2. enforces the required *narrow* scope for the operation
+     (``gitea:read`` to list, ``gitea:write`` to create),
+  3. only then proxies to Gitea, using a server-side admin credential the
+     caller never sees.
+
+This is the "the token actually grants access to something" moment: a
+read-only token can list repositories but is refused (HTTP 403) when it tries
+to create one.
+"""
+
+from __future__ import annotations
+
+import os
+
+import httpx
+import jwt as pyjwt
+from fastapi import Depends, FastAPI, Header, HTTPException
+from pydantic import BaseModel
+
+KEYCLOAK_URL = os.environ.get("KEYCLOAK_URL", "http://keycloak:8080").rstrip("/")
+REALM = os.environ.get("KEYCLOAK_REALM", "cncf-demo")
+ISSUER = os.environ.get("KEYCLOAK_ISSUER", f"{KEYCLOAK_URL}/realms/{REALM}")
+JWKS_URL = f"{KEYCLOAK_URL}/realms/{REALM}/protocol/openid-connect/certs"
+
+GITEA_URL = os.environ.get("GITEA_URL", "http://gitea:3000").rstrip("/")
+GITEA_ADMIN_USER = os.environ.get("GITEA_ADMIN_USER", "demo-admin")
+GITEA_ADMIN_PASSWORD = os.environ.get("GITEA_ADMIN_PASSWORD", "")
+
+READ_SCOPE = os.environ.get("GITEA_READ_SCOPE", "gitea:read")
+WRITE_SCOPE = os.environ.get("GITEA_WRITE_SCOPE", "gitea:write")
+
+app = FastAPI(title="CNCF Demo — Gitea Gateway", version="0.1.0")
+
+# PyJWKClient caches keys and refreshes on unknown kid.
+_jwks = pyjwt.PyJWKClient(JWKS_URL)
+
+
+def _verify_token(authorization: str | None) -> dict:
+    """Verify the bearer token and return its claims, or raise 401."""
+    if not authorization or not authorization.lower().startswith("bearer "):
+        raise HTTPException(status_code=401, detail="missing bearer token")
+    token = authorization.split(" ", 1)[1].strip()
+    try:
+        signing_key = _jwks.get_signing_key_from_jwt(token)
+        claims = pyjwt.decode(
+            token,
+            signing_key.key,
+            algorithms=["RS256"],
+            issuer=ISSUER,
+            # Keycloak access tokens are audience-multi; scope is what we gate on.
+            options={"verify_aud": False},
+        )
+    except Exception as exc:  # noqa: BLE001
+        raise HTTPException(status_code=401, detail=f"invalid token: {exc}") from exc
+    return claims
+
+
+def require_token(authorization: str | None = Header(default=None)) -> dict:
+    return _verify_token(authorization)
+
+
+def _scopes(claims: dict) -> set[str]:
+    return set(str(claims.get("scope", "")).split())
+
+
+def require_scope(claims: dict, needed: str) -> None:
+    granted = _scopes(claims)
+    if needed not in granted:
+        raise HTTPException(
+            status_code=403,
+            detail={
+                "error": "insufficient_scope",
+                "required": needed,
+                "granted": sorted(granted),
+                "message": f"token is missing the '{needed}' scope",
+            },
+        )
+
+
+def _gitea_auth() -> tuple[str, str]:
+    return (GITEA_ADMIN_USER, GITEA_ADMIN_PASSWORD)
+
+
+class CreateRepo(BaseModel):
+    name: str
+    description: str = "Created via the ID-JAG demo gateway"
+    private: bool = False
+
+
+@app.get("/healthz")
+def healthz():
+    return {"status": "ok"}
+
+
+@app.get("/api/gitea/repos")
+async def list_repos(claims: dict = Depends(require_token)):
+    """List Gitea repositories. Requires the narrow ``gitea:read`` scope."""
+    require_scope(claims, READ_SCOPE)
+    async with httpx.AsyncClient(timeout=15) as client:
+        r = await client.get(
+            f"{GITEA_URL}/api/v1/repos/search",
+            params={"limit": 50},
+            auth=_gitea_auth(),
+        )
+    if r.status_code != 200:
+        raise HTTPException(status_code=502, detail=f"gitea error: {r.text[:200]}")
+    repos = [
+        {
+            "full_name": item.get("full_name"),
+            "private": item.get("private"),
+            "description": item.get("description"),
+            "html_url": item.get("html_url"),
+        }
+        for item in r.json().get("data", [])
+    ]
+    return {"subject": claims.get("sub"), "scope": sorted(_scopes(claims)), "repos": repos}
+
+
+@app.post("/api/gitea/repos")
+async def create_repo(body: CreateRepo, claims: dict = Depends(require_token)):
+    """Create a Gitea repository. Requires the ``gitea:write`` scope."""
+    require_scope(claims, WRITE_SCOPE)
+    async with httpx.AsyncClient(timeout=15) as client:
+        r = await client.post(
+            f"{GITEA_URL}/api/v1/user/repos",
+            json={"name": body.name, "description": body.description,
+                  "private": body.private, "auto_init": True},
+            auth=_gitea_auth(),
+        )
+    if r.status_code not in (200, 201):
+        raise HTTPException(status_code=502, detail=f"gitea error: {r.text[:200]}")
+    item = r.json()
+    return {
+        "subject": claims.get("sub"),
+        "scope": sorted(_scopes(claims)),
+        "created": {"full_name": item.get("full_name"), "html_url": item.get("html_url")},
+    }

--- a/demos/cncf-stack/gitea-gateway/requirements-dev.txt
+++ b/demos/cncf-stack/gitea-gateway/requirements-dev.txt
@@ -1,0 +1,4 @@
+-r requirements.txt
+pytest
+# Mocks the outbound httpx calls to Gitea.
+respx

--- a/demos/cncf-stack/gitea-gateway/requirements.txt
+++ b/demos/cncf-stack/gitea-gateway/requirements.txt
@@ -1,0 +1,5 @@
+fastapi==0.115.6
+uvicorn==0.34.0
+httpx==0.28.1
+pyjwt==2.10.1
+cryptography==44.0.0

--- a/demos/cncf-stack/gitea-gateway/tests/conftest.py
+++ b/demos/cncf-stack/gitea-gateway/tests/conftest.py
@@ -1,0 +1,5 @@
+import os
+import sys
+
+# Make the gateway package (app.py) importable when running pytest from anywhere.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))

--- a/demos/cncf-stack/gitea-gateway/tests/test_app.py
+++ b/demos/cncf-stack/gitea-gateway/tests/test_app.py
@@ -1,0 +1,120 @@
+"""Unit tests for the Gitea gateway.
+
+These focus on the security contract the demo depends on: the token is verified
+(RS256 via JWKS, issuer, expiry) and the *narrow* scope is enforced before any
+call reaches Gitea. Gitea itself is mocked with respx.
+"""
+
+import time
+import types
+
+import httpx
+import jwt as pyjwt
+import pytest
+import respx
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from fastapi.testclient import TestClient
+
+import app as gw
+
+client = TestClient(gw.app)
+
+_KEY = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+_PRIV_PEM = _KEY.private_bytes(
+    serialization.Encoding.PEM,
+    serialization.PrivateFormat.PKCS8,
+    serialization.NoEncryption(),
+)
+_PUB_PEM = _KEY.public_key().public_bytes(
+    serialization.Encoding.PEM, serialization.PublicFormat.SubjectPublicKeyInfo
+)
+
+
+@pytest.fixture(autouse=True)
+def _patch_jwks(monkeypatch):
+    """Return our test public key for any token, mimicking a JWKS lookup."""
+    fake = types.SimpleNamespace(
+        get_signing_key_from_jwt=lambda token: types.SimpleNamespace(key=_PUB_PEM)
+    )
+    monkeypatch.setattr(gw, "_jwks", fake)
+
+
+def _token(scope="gitea:read", iss=None, exp_delta=300) -> str:
+    now = int(time.time())
+    payload = {
+        "iss": iss or gw.ISSUER,
+        "sub": "user@example.com",
+        "iat": now,
+        "exp": now + exp_delta,
+        "scope": scope,
+    }
+    return pyjwt.encode(payload, _PRIV_PEM, algorithm="RS256")
+
+
+def _auth(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_healthz():
+    assert client.get("/healthz").json() == {"status": "ok"}
+
+
+def test_list_requires_bearer_token():
+    assert client.get("/api/gitea/repos").status_code == 401
+
+
+def test_list_rejects_garbage_token():
+    assert client.get("/api/gitea/repos", headers=_auth("not-a-jwt")).status_code == 401
+
+
+def test_list_rejects_wrong_issuer():
+    tok = _token(scope="gitea:read", iss="http://evil/realms/other")
+    assert client.get("/api/gitea/repos", headers=_auth(tok)).status_code == 401
+
+
+def test_list_rejects_expired_token():
+    tok = _token(scope="gitea:read", exp_delta=-10)
+    assert client.get("/api/gitea/repos", headers=_auth(tok)).status_code == 401
+
+
+def test_list_denied_without_read_scope():
+    tok = _token(scope="openid profile")
+    r = client.get("/api/gitea/repos", headers=_auth(tok))
+    assert r.status_code == 403
+    assert r.json()["detail"]["required"] == "gitea:read"
+
+
+@respx.mock
+def test_list_ok_with_read_scope():
+    respx.get(f"{gw.GITEA_URL}/api/v1/repos/search").mock(
+        return_value=httpx.Response(200, json={"data": [
+            {"full_name": "demo/payments", "private": False, "description": "d", "html_url": "u"},
+        ]})
+    )
+    tok = _token(scope="openid gitea:read")
+    r = client.get("/api/gitea/repos", headers=_auth(tok))
+    assert r.status_code == 200
+    body = r.json()
+    assert body["repos"][0]["full_name"] == "demo/payments"
+    assert "gitea:read" in body["scope"]
+
+
+def test_create_denied_without_write_scope():
+    """The narrow-scoping payoff: a read-only token cannot create a repo."""
+    tok = _token(scope="openid gitea:read")
+    r = client.post("/api/gitea/repos", headers=_auth(tok), json={"name": "x"})
+    assert r.status_code == 403
+    assert r.json()["detail"]["required"] == "gitea:write"
+
+
+@respx.mock
+def test_create_ok_with_write_scope():
+    route = respx.post(f"{gw.GITEA_URL}/api/v1/user/repos").mock(
+        return_value=httpx.Response(201, json={"full_name": "demo/new", "html_url": "u"})
+    )
+    tok = _token(scope="openid gitea:read gitea:write")
+    r = client.post("/api/gitea/repos", headers=_auth(tok), json={"name": "new"})
+    assert r.status_code == 200
+    assert r.json()["created"]["full_name"] == "demo/new"
+    assert route.called

--- a/demos/cncf-stack/gitea/init.sh
+++ b/demos/cncf-stack/gitea/init.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+# Bootstraps Gitea for the ID-JAG narrow-scoping demo:
+#   1. creates an admin user (idempotent),
+#   2. seeds a couple of demo repositories the Receiving App can read/write.
+#
+# Runs as a one-shot container sharing Gitea's data volume (for the CLI) and
+# its network (for the API). Safe to re-run.
+set -eu
+
+CONF=/data/gitea/conf/app.ini
+GITEA_URL="${GITEA_INTERNAL_URL:-http://gitea:3000}"
+ADMIN_USER="${GITEA_ADMIN_USER:-demo-admin}"
+ADMIN_PW="${GITEA_ADMIN_PASSWORD:?GITEA_ADMIN_PASSWORD required}"
+ADMIN_EMAIL="${GITEA_ADMIN_EMAIL:-admin@example.com}"
+
+echo "[gitea-init] waiting for Gitea config at ${CONF} ..."
+for i in $(seq 1 60); do
+  [ -f "$CONF" ] && break
+  sleep 2
+done
+
+echo "[gitea-init] ensuring admin user '${ADMIN_USER}' exists"
+if gitea admin user list --config "$CONF" 2>/dev/null | awk '{print $2}' | grep -qx "$ADMIN_USER"; then
+  echo "[gitea-init] admin user already present"
+else
+  for i in $(seq 1 5); do
+    if gitea admin user create --admin --username "$ADMIN_USER" \
+         --password "$ADMIN_PW" --email "$ADMIN_EMAIL" \
+         --must-change-password=false --config "$CONF" 2>&1; then
+      break
+    fi
+    echo "[gitea-init] create retry $i ..."; sleep 3
+  done
+fi
+
+echo "[gitea-init] waiting for Gitea API ..."
+AUTH="Authorization: Basic $(printf '%s' "${ADMIN_USER}:${ADMIN_PW}" | base64)"
+for i in $(seq 1 60); do
+  if wget -q -O- --header="$AUTH" "${GITEA_URL}/api/v1/version" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 2
+done
+
+seed_repo() {
+  name="$1"; desc="$2"
+  if wget -q -O- --header="$AUTH" "${GITEA_URL}/api/v1/repos/${ADMIN_USER}/${name}" >/dev/null 2>&1; then
+    echo "[gitea-init] repo '${name}' already exists"
+    return
+  fi
+  echo "[gitea-init] creating repo '${name}'"
+  wget -q -O- --header="Content-Type: application/json" --header="$AUTH" \
+    --post-data="{\"name\":\"${name}\",\"private\":false,\"auto_init\":true,\"description\":\"${desc}\"}" \
+    "${GITEA_URL}/api/v1/user/repos" >/dev/null 2>&1 || echo "[gitea-init] WARN: could not create ${name}"
+}
+
+seed_repo "payments-service" "Payments microservice configuration (demo)"
+seed_repo "audit-logs"       "Read-only audit log archive (demo)"
+
+echo "[gitea-init] done."

--- a/demos/cncf-stack/idjag-issuer/Dockerfile
+++ b/demos/cncf-stack/idjag-issuer/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY app.py .
+
+ENV PYTHONUNBUFFERED=1
+EXPOSE 9000
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "9000"]

--- a/demos/cncf-stack/idjag-issuer/app.py
+++ b/demos/cncf-stack/idjag-issuer/app.py
@@ -1,0 +1,122 @@
+"""Minimal ID-JAG issuer for the CNCF demo.
+
+Stands in for the "central enterprise IdP" that mints Identity Assertion JWT
+Authorization Grants (ID-JAG). Keycloak 26.7 can only *receive* ID-JAG today,
+so this tiny service plays the *issuer* role:
+
+  - Holds an RSA key pair generated at startup.
+  - Publishes its public key as a JWKS (so Keycloak's `id-jag` identity
+    provider can validate the assertion signature).
+  - Mints signed ID-JAG assertions on demand (POST /mint).
+
+This is a demo helper — not a production IdP.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+import uuid
+
+import jwt
+from cryptography.hazmat.primitives.asymmetric import rsa
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+# Issuer identity as reachable from Keycloak on the docker network.
+ISSUER_URL = os.environ.get("ISSUER_URL", "http://idjag-issuer:9000")
+# ID-JAG assertion media type from the IETF draft.
+IDJAG_TYP = "oauth-id-jag+jwt"
+ASSERTION_TTL = int(os.environ.get("ASSERTION_TTL", "300"))
+
+_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+_kid = str(uuid.uuid4())
+
+app = FastAPI(title="CNCF Demo ID-JAG Issuer", version="0.1.0")
+
+
+def _int_to_b64url(value: int, length: int) -> str:
+    import base64
+
+    return base64.urlsafe_b64encode(value.to_bytes(length, "big")).rstrip(b"=").decode()
+
+
+def _public_jwk() -> dict:
+    nums = _key.public_key().public_numbers()
+    return {
+        "kty": "RSA",
+        "use": "sig",
+        "alg": "RS256",
+        "kid": _kid,
+        "n": _int_to_b64url(nums.n, (nums.n.bit_length() + 7) // 8),
+        "e": _int_to_b64url(nums.e, (nums.e.bit_length() + 7) // 8),
+    }
+
+
+@app.get("/healthz")
+def healthz():
+    return {"status": "ok"}
+
+
+@app.get("/jwks")
+@app.get("/protocol/openid-connect/certs")
+def jwks():
+    return {"keys": [_public_jwk()]}
+
+
+@app.get("/.well-known/openid-configuration")
+def discovery():
+    return JSONResponse(
+        {
+            "issuer": ISSUER_URL,
+            "authorization_endpoint": f"{ISSUER_URL}/auth",
+            "token_endpoint": f"{ISSUER_URL}/token",
+            "jwks_uri": f"{ISSUER_URL}/jwks",
+            "response_types_supported": ["code"],
+            "subject_types_supported": ["public"],
+            "id_token_signing_alg_values_supported": ["RS256"],
+        }
+    )
+
+
+class MintRequest(BaseModel):
+    # Subject the assertion represents. Must match a federated identity link
+    # (identityProvider=id-jag, userId=<sub>) on the receiving Keycloak realm.
+    sub: str
+    # Target audience — the receiving authorization server / realm.
+    aud: str
+    # Requesting client id (Client App A). Keycloak's ID-JAG receiver requires
+    # this to match the client presenting the assertion at its token endpoint.
+    client_id: str | None = None
+    # Optional acting agent chain, mirrored into the `act` claim.
+    act_chain: list[str] | None = None
+    scope: str | None = None
+
+
+@app.post("/mint")
+def mint(body: MintRequest):
+    now = int(time.time())
+    claims = {
+        "iss": ISSUER_URL,
+        "sub": body.sub,
+        "aud": body.aud,
+        "iat": now,
+        "exp": now + ASSERTION_TTL,
+        "jti": str(uuid.uuid4()),
+    }
+    if body.client_id:
+        claims["client_id"] = body.client_id
+        claims["azp"] = body.client_id
+    if body.scope:
+        claims["scope"] = body.scope
+    if body.act_chain:
+        claims["act"] = {"sub": body.act_chain[-1], "act_chain": body.act_chain}
+
+    assertion = jwt.encode(
+        claims,
+        _key,
+        algorithm="RS256",
+        headers={"kid": _kid, "typ": IDJAG_TYP},
+    )
+    return {"assertion": assertion, "claims": claims}

--- a/demos/cncf-stack/idjag-issuer/requirements-dev.txt
+++ b/demos/cncf-stack/idjag-issuer/requirements-dev.txt
@@ -1,0 +1,4 @@
+-r requirements.txt
+pytest
+# FastAPI's TestClient is backed by httpx/starlette.
+httpx

--- a/demos/cncf-stack/idjag-issuer/requirements.txt
+++ b/demos/cncf-stack/idjag-issuer/requirements.txt
@@ -1,0 +1,4 @@
+fastapi==0.115.6
+uvicorn==0.34.0
+pyjwt==2.10.1
+cryptography==44.0.0

--- a/demos/cncf-stack/idjag-issuer/tests/conftest.py
+++ b/demos/cncf-stack/idjag-issuer/tests/conftest.py
@@ -1,0 +1,5 @@
+import os
+import sys
+
+# Make the issuer package (app.py) importable when running pytest from anywhere.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))

--- a/demos/cncf-stack/idjag-issuer/tests/test_app.py
+++ b/demos/cncf-stack/idjag-issuer/tests/test_app.py
@@ -1,0 +1,123 @@
+"""Unit tests for the CNCF demo ID-JAG issuer.
+
+Covers the JWKS/discovery endpoints and the /mint assertion contract that
+Keycloak's ID-JAG receiver relies on (claims, header type, signature).
+"""
+
+import json
+
+import jwt as pyjwt
+import pytest
+from fastapi.testclient import TestClient
+
+import app as issuer
+
+client = TestClient(issuer.app)
+
+REALM_AUD = "http://keycloak:8080/realms/cncf-demo"
+
+
+def _verify_key():
+    """Build a public key object from the published JWKS (as Keycloak would)."""
+    jwk = client.get("/jwks").json()["keys"][0]
+    return pyjwt.algorithms.RSAAlgorithm.from_jwk(json.dumps(jwk))
+
+
+def test_healthz():
+    r = client.get("/healthz")
+    assert r.status_code == 200
+    assert r.json() == {"status": "ok"}
+
+
+def test_jwks_shape():
+    r = client.get("/jwks")
+    assert r.status_code == 200
+    keys = r.json()["keys"]
+    assert len(keys) == 1
+    jwk = keys[0]
+    assert jwk["kty"] == "RSA"
+    assert jwk["use"] == "sig"
+    assert jwk["alg"] == "RS256"
+    assert jwk["kid"] == issuer._kid
+    assert jwk["n"] and jwk["e"]
+
+
+def test_certs_alias_matches_jwks():
+    assert client.get("/protocol/openid-connect/certs").json() == client.get("/jwks").json()
+
+
+def test_discovery_document():
+    doc = client.get("/.well-known/openid-configuration").json()
+    assert doc["issuer"] == issuer.ISSUER_URL
+    assert doc["jwks_uri"] == f"{issuer.ISSUER_URL}/jwks"
+    assert "RS256" in doc["id_token_signing_alg_values_supported"]
+
+
+def test_mint_minimal_claims_and_header():
+    r = client.post("/mint", json={"sub": "user@example.com", "aud": REALM_AUD})
+    assert r.status_code == 200
+    body = r.json()
+    assertion = body["assertion"]
+
+    header = pyjwt.get_unverified_header(assertion)
+    assert header["typ"] == issuer.IDJAG_TYP
+    assert header["kid"] == issuer._kid
+    assert header["alg"] == "RS256"
+
+    claims = body["claims"]
+    assert claims["iss"] == issuer.ISSUER_URL
+    assert claims["sub"] == "user@example.com"
+    assert claims["aud"] == REALM_AUD
+    assert claims["exp"] - claims["iat"] == issuer.ASSERTION_TTL
+    assert claims["jti"]
+    # Optional claims must be absent when not requested.
+    assert "client_id" not in claims
+    assert "azp" not in claims
+    assert "scope" not in claims
+    assert "act" not in claims
+
+
+def test_mint_signature_verifies_against_jwks():
+    assertion = client.post(
+        "/mint", json={"sub": "user@example.com", "aud": REALM_AUD}
+    ).json()["assertion"]
+    # Verifying with the wrong audience must fail; the right one must pass.
+    decoded = pyjwt.decode(assertion, _verify_key(), algorithms=["RS256"], audience=REALM_AUD)
+    assert decoded["sub"] == "user@example.com"
+    with pytest.raises(pyjwt.InvalidAudienceError):
+        pyjwt.decode(assertion, _verify_key(), algorithms=["RS256"], audience="wrong")
+
+
+def test_mint_with_client_id_sets_azp():
+    claims = client.post(
+        "/mint",
+        json={"sub": "user@example.com", "aud": REALM_AUD, "client_id": "receiving-app"},
+    ).json()["claims"]
+    assert claims["client_id"] == "receiving-app"
+    assert claims["azp"] == "receiving-app"
+
+
+def test_mint_with_scope_and_act_chain():
+    claims = client.post(
+        "/mint",
+        json={
+            "sub": "user@example.com",
+            "aud": REALM_AUD,
+            "scope": "openid",
+            "act_chain": ["user", "receiving-app"],
+        },
+    ).json()["claims"]
+    assert claims["scope"] == "openid"
+    assert claims["act"] == {"sub": "receiving-app", "act_chain": ["user", "receiving-app"]}
+
+
+def test_mint_requires_sub_and_aud():
+    assert client.post("/mint", json={"sub": "only-sub"}).status_code == 422
+    assert client.post("/mint", json={}).status_code == 422
+
+
+def test_mint_generates_unique_jti():
+    req = {"sub": "user@example.com", "aud": REALM_AUD}
+    a = client.post("/mint", json=req).json()["claims"]["jti"]
+    b = client.post("/mint", json=req).json()["claims"]["jti"]
+    assert a != b

--- a/demos/cncf-stack/keycloak/bootstrap-scopes.sh
+++ b/demos/cncf-stack/keycloak/bootstrap-scopes.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Registers the narrow "gitea:read" / "gitea:write" client scopes in the
+# cncf-demo realm and assigns them as OPTIONAL scopes to the Receiving App.
+#
+# Run after Keycloak has imported the realm (see the kc-init service). It uses
+# kcadm.sh and is idempotent — re-running is safe.
+set -euo pipefail
+
+KC="${KC_URL:-http://keycloak:8080}"
+REALM="${KC_REALM:-cncf-demo}"
+ADMIN="${KC_ADMIN:-admin}"
+ADMIN_PW="${KC_ADMIN_PASSWORD:?KC_ADMIN_PASSWORD required}"
+CLIENT_ID="${RECEIVER_CLIENT:-receiving-app}"
+KCADM=/opt/keycloak/bin/kcadm.sh
+
+echo "[kc-init] waiting for Keycloak at ${KC} ..."
+for i in $(seq 1 60); do
+  if "$KCADM" config credentials --server "$KC" --realm master \
+       --user "$ADMIN" --password "$ADMIN_PW" >/dev/null 2>&1; then
+    echo "[kc-init] authenticated to Keycloak admin"
+    break
+  fi
+  sleep 3
+done
+
+create_scope() {
+  local name="$1" desc="$2"
+  if "$KCADM" get client-scopes -r "$REALM" --fields name --format csv --noquotes 2>/dev/null | grep -qx "$name"; then
+    echo "[kc-init] client scope '$name' already exists"
+  else
+    echo "[kc-init] creating client scope '$name'"
+    "$KCADM" create client-scopes -r "$REALM" \
+      -s name="$name" \
+      -s description="$desc" \
+      -s protocol=openid-connect \
+      -s 'attributes."include.in.token.scope"=true' \
+      -s 'attributes."display.on.consent.screen"=false'
+  fi
+}
+
+assign_optional() {
+  local scope_name="$1"
+  local cid sid
+  cid=$("$KCADM" get clients -r "$REALM" -q clientId="$CLIENT_ID" --fields id --format csv --noquotes | head -n1)
+  sid=$("$KCADM" get client-scopes -r "$REALM" --fields id,name --format csv --noquotes \
+        | grep ",${scope_name}$" | cut -d, -f1 | head -n1)
+  if [ -z "$cid" ] || [ -z "$sid" ]; then
+    echo "[kc-init] ERROR: could not resolve client ($cid) or scope ($scope_name -> $sid)"
+    return 1
+  fi
+  echo "[kc-init] assigning optional scope '$scope_name' to '$CLIENT_ID'"
+  "$KCADM" update "clients/${cid}/optional-client-scopes/${sid}" -r "$REALM" >/dev/null 2>&1 || true
+}
+
+create_scope "gitea:read"  "Read-only access to Gitea repositories"
+create_scope "gitea:write" "Write access to Gitea repositories (create/modify)"
+assign_optional "gitea:read"
+assign_optional "gitea:write"
+
+echo "[kc-init] done."

--- a/demos/cncf-stack/keycloak/cncf-demo-realm.json
+++ b/demos/cncf-stack/keycloak/cncf-demo-realm.json
@@ -14,10 +14,10 @@
       "storeToken": false,
       "addReadTokenRoleOnCreate": false,
       "config": {
-        "issuer": "https://issuer.example.com/realms/enterprise",
-        "authorizationUrl": "https://issuer.example.com/realms/enterprise/protocol/openid-connect/auth",
-        "tokenUrl": "https://issuer.example.com/realms/enterprise/protocol/openid-connect/token",
-        "jwksUrl": "https://issuer.example.com/realms/enterprise/protocol/openid-connect/certs",
+        "issuer": "http://idjag-issuer:9000",
+        "authorizationUrl": "http://idjag-issuer:9000/auth",
+        "tokenUrl": "http://idjag-issuer:9000/token",
+        "jwksUrl": "http://idjag-issuer:9000/jwks",
         "useJwksUrl": "true",
         "clientId": "cncf-demo-receiver",
         "clientSecret": "demo-idjag-secret-change-me",
@@ -70,6 +70,9 @@
       "emailVerified": true,
       "credentials": [
         { "type": "password", "value": "demo-password-change-me", "temporary": false }
+      ],
+      "federatedIdentities": [
+        { "identityProvider": "id-jag", "userId": "sarah@enterprisex.com", "userName": "sarah" }
       ]
     },
     {

--- a/demos/cncf-stack/keycloak/cncf-demo-realm.json
+++ b/demos/cncf-stack/keycloak/cncf-demo-realm.json
@@ -48,7 +48,7 @@
     {
       "clientId": "receiving-app",
       "name": "Receiving App (ID-JAG receiver)",
-      "description": "Receiving application. Exchanges an incoming ID-JAG assertion (jwt-bearer grant) for a local access token.",
+      "description": "Receiving application. Exchanges an incoming ID-JAG assertion (jwt-bearer grant) for a local access token, then calls Gitea with it.",
       "enabled": true,
       "publicClient": false,
       "secret": "demo-receiving-secret-change-me",

--- a/demos/cncf-stack/keycloak/cncf-demo-realm.json
+++ b/demos/cncf-stack/keycloak/cncf-demo-realm.json
@@ -1,0 +1,87 @@
+{
+  "realm": "cncf-demo",
+  "enabled": true,
+  "registrationAllowed": false,
+  "resetPasswordAllowed": false,
+  "sslRequired": "external",
+  "identityProviders": [
+    {
+      "alias": "id-jag",
+      "displayName": "ID-JAG Issuer",
+      "providerId": "keycloak-oidc",
+      "enabled": true,
+      "trustEmail": true,
+      "storeToken": false,
+      "addReadTokenRoleOnCreate": false,
+      "config": {
+        "issuer": "https://issuer.example.com/realms/enterprise",
+        "authorizationUrl": "https://issuer.example.com/realms/enterprise/protocol/openid-connect/auth",
+        "tokenUrl": "https://issuer.example.com/realms/enterprise/protocol/openid-connect/token",
+        "jwksUrl": "https://issuer.example.com/realms/enterprise/protocol/openid-connect/certs",
+        "useJwksUrl": "true",
+        "clientId": "cncf-demo-receiver",
+        "clientSecret": "demo-idjag-secret-change-me",
+        "jwtAuthorizationGrantEnabled": "true",
+        "jwtAuthorizationGrantAssertionReuseAllowed": "false",
+        "jwtAuthorizationGrantMaxAllowedAssertionExpiration": "300"
+      }
+    }
+  ],
+  "clients": [
+    {
+      "clientId": "cncf-demo-client",
+      "name": "CNCF Demo Client",
+      "description": "Primary confidential client (standard flow, direct grants, standard token exchange).",
+      "enabled": true,
+      "publicClient": false,
+      "secret": "demo-client-secret-change-me",
+      "standardFlowEnabled": true,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "redirectUris": ["http://localhost:8080/callback", "*"],
+      "webOrigins": ["+"],
+      "attributes": {
+        "standard.token.exchange.enabled": "true",
+        "post.logout.redirect.uris": "+"
+      }
+    },
+    {
+      "clientId": "backend-client",
+      "name": "Backend Client (ID-JAG receiver)",
+      "description": "Exchanges an incoming ID-JAG assertion (jwt-bearer grant) for a local access token.",
+      "enabled": true,
+      "publicClient": false,
+      "secret": "demo-backend-secret-change-me",
+      "serviceAccountsEnabled": true,
+      "consentRequired": false,
+      "attributes": {
+        "oauth2.jwt.authorization.grant.enabled": "true",
+        "oauth2.jwt.authorization.grant.idp": "id-jag"
+      }
+    }
+  ],
+  "users": [
+    {
+      "username": "sarah",
+      "email": "sarah@enterprisex.com",
+      "firstName": "Sarah",
+      "lastName": "Demo",
+      "enabled": true,
+      "emailVerified": true,
+      "credentials": [
+        { "type": "password", "value": "demo-password-change-me", "temporary": false }
+      ]
+    },
+    {
+      "username": "alice",
+      "email": "alice@enterprisex.com",
+      "firstName": "Alice",
+      "lastName": "Demo",
+      "enabled": true,
+      "emailVerified": true,
+      "credentials": [
+        { "type": "password", "value": "demo-password-change-me", "temporary": false }
+      ]
+    }
+  ]
+}

--- a/demos/cncf-stack/keycloak/cncf-demo-realm.json
+++ b/demos/cncf-stack/keycloak/cncf-demo-realm.json
@@ -19,7 +19,7 @@
         "tokenUrl": "http://idjag-issuer:9000/token",
         "jwksUrl": "http://idjag-issuer:9000/jwks",
         "useJwksUrl": "true",
-        "clientId": "cncf-demo-receiver",
+        "clientId": "idjag-receiver",
         "clientSecret": "demo-idjag-secret-change-me",
         "jwtAuthorizationGrantEnabled": "true",
         "jwtAuthorizationGrantAssertionReuseAllowed": "false",
@@ -29,12 +29,12 @@
   ],
   "clients": [
     {
-      "clientId": "cncf-demo-client",
-      "name": "CNCF Demo Client",
-      "description": "Primary confidential client (standard flow, direct grants, standard token exchange).",
+      "clientId": "requesting-app",
+      "name": "Requesting App",
+      "description": "Requesting application. Signs the user in and initiates cross-app access to the Receiving App.",
       "enabled": true,
       "publicClient": false,
-      "secret": "demo-client-secret-change-me",
+      "secret": "demo-requesting-secret-change-me",
       "standardFlowEnabled": true,
       "directAccessGrantsEnabled": true,
       "serviceAccountsEnabled": true,
@@ -46,12 +46,12 @@
       }
     },
     {
-      "clientId": "backend-client",
-      "name": "Backend Client (ID-JAG receiver)",
-      "description": "Exchanges an incoming ID-JAG assertion (jwt-bearer grant) for a local access token.",
+      "clientId": "receiving-app",
+      "name": "Receiving App (ID-JAG receiver)",
+      "description": "Receiving application. Exchanges an incoming ID-JAG assertion (jwt-bearer grant) for a local access token.",
       "enabled": true,
       "publicClient": false,
-      "secret": "demo-backend-secret-change-me",
+      "secret": "demo-receiving-secret-change-me",
       "serviceAccountsEnabled": true,
       "consentRequired": false,
       "attributes": {
@@ -62,28 +62,17 @@
   ],
   "users": [
     {
-      "username": "sarah",
-      "email": "sarah@enterprisex.com",
-      "firstName": "Sarah",
-      "lastName": "Demo",
+      "username": "user",
+      "email": "user@example.com",
+      "firstName": "Demo",
+      "lastName": "User",
       "enabled": true,
       "emailVerified": true,
       "credentials": [
         { "type": "password", "value": "demo-password-change-me", "temporary": false }
       ],
       "federatedIdentities": [
-        { "identityProvider": "id-jag", "userId": "sarah@enterprisex.com", "userName": "sarah" }
-      ]
-    },
-    {
-      "username": "alice",
-      "email": "alice@enterprisex.com",
-      "firstName": "Alice",
-      "lastName": "Demo",
-      "enabled": true,
-      "emailVerified": true,
-      "credentials": [
-        { "type": "password", "value": "demo-password-change-me", "temporary": false }
+        { "identityProvider": "id-jag", "userId": "user@example.com", "userName": "user" }
       ]
     }
   ]

--- a/demos/cncf-stack/webapp/Dockerfile
+++ b/demos/cncf-stack/webapp/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY app.py .
+COPY static ./static
+
+ENV PYTHONUNBUFFERED=1
+EXPOSE 8000
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/demos/cncf-stack/webapp/app.py
+++ b/demos/cncf-stack/webapp/app.py
@@ -11,15 +11,22 @@ issuer directly (no CORS):
   2. Mint ID-JAG          — request a signed assertion (for the Receiving App) from the issuer
   3. Receiving App exchange — present the assertion to Keycloak's receiving-app token
                           endpoint via the jwt-bearer grant -> access token
+  4. Read Gitea           — call the gitea-gateway to LIST repos (needs gitea:read)
+  5. Write Gitea          — call the gitea-gateway to CREATE a repo (needs gitea:write)
 
-Each hop is exposed both as part of /api/run (all three at once) and as an
-individual /api/step/<id> endpoint, so the UI can either animate the sequence
-or let the presenter step through it one hop at a time.
+The requested scope is chosen by the caller. With a read-only scope the write
+hop is *correctly refused* (HTTP 403) by the gateway — that is the narrow
+scoping payoff.
+
+Each hop is exposed both as part of /api/run (the whole sequence at once) and
+as an individual /api/step/<id> endpoint, so the UI can either animate the
+sequence or let the presenter step through it one hop at a time.
 """
 
 from __future__ import annotations
 
 import os
+import secrets
 
 import httpx
 import jwt as pyjwt
@@ -38,9 +45,19 @@ DEMO_USER = os.environ.get("DEMO_USER", "user")
 DEMO_PASSWORD = os.environ.get("DEMO_PASSWORD", "")
 SUBJECT = os.environ.get("IDJAG_SUBJECT", "user@example.com")
 ISSUER_URL = os.environ.get("IDJAG_ISSUER_URL", "http://idjag-issuer:9000").rstrip("/")
+GATEWAY_URL = os.environ.get("GITEA_GATEWAY_URL", "http://gitea-gateway:9100").rstrip("/")
 
 TOKEN_ENDPOINT = f"{KEYCLOAK_URL}/realms/{REALM}/protocol/openid-connect/token"
 REALM_ISSUER = f"{KEYCLOAK_URL}/realms/{REALM}"
+
+# The scope requested through the whole chain. Read-only is the default so the
+# write hop demonstrates the gateway refusing an out-of-scope operation.
+DEFAULT_SCOPE = "openid gitea:read"
+
+
+def _default_repo_name() -> str:
+    # Unique per call so repeated demo runs don't collide on an existing repo.
+    return f"created-by-idjag-{secrets.token_hex(3)}"
 
 app = FastAPI(title="CNCF Demo — ID-JAG", version="0.1.0")
 
@@ -90,11 +107,11 @@ async def _login(client: httpx.AsyncClient) -> dict:
     return step
 
 
-async def _mint(client: httpx.AsyncClient) -> dict:
+async def _mint(client: httpx.AsyncClient, scope: str = DEFAULT_SCOPE) -> dict:
     step = {
         "id": "mint",
         "title": "2. Mint ID-JAG assertion (for the Receiving App)",
-        "detail": f"POST {ISSUER_URL}/mint  (sub={SUBJECT}, aud={REALM_ISSUER})",
+        "detail": f"POST {ISSUER_URL}/mint  (sub={SUBJECT}, aud={REALM_ISSUER}, scope={scope})",
     }
     try:
         r = await client.post(
@@ -107,7 +124,7 @@ async def _mint(client: httpx.AsyncClient) -> dict:
                 "aud": REALM_ISSUER,
                 "client_id": BACKEND_CLIENT_ID,
                 "act_chain": [USER_CLIENT_ID],
-                "scope": "openid",
+                "scope": scope,
             },
         )
         if r.status_code != 200:
@@ -120,11 +137,11 @@ async def _mint(client: httpx.AsyncClient) -> dict:
     return step
 
 
-async def _exchange(client: httpx.AsyncClient, assertion: str) -> dict:
+async def _exchange(client: httpx.AsyncClient, assertion: str, scope: str = DEFAULT_SCOPE) -> dict:
     step = {
         "id": "exchange",
         "title": "3. Receiving App — exchange (Keycloak ID-JAG / jwt-bearer)",
-        "detail": f"POST {TOKEN_ENDPOINT}  (grant_type=jwt-bearer, client={BACKEND_CLIENT_ID})",
+        "detail": f"POST {TOKEN_ENDPOINT}  (grant_type=jwt-bearer, client={BACKEND_CLIENT_ID}, scope={scope})",
     }
     if not assertion:
         step.update(status="error", error="no assertion provided (run the mint step first)")
@@ -137,7 +154,7 @@ async def _exchange(client: httpx.AsyncClient, assertion: str) -> dict:
                 "assertion": assertion,
                 "client_id": BACKEND_CLIENT_ID,
                 "client_secret": BACKEND_CLIENT_SECRET,
-                "scope": "openid",
+                "scope": scope,
             },
         )
         if r.status_code != 200:
@@ -145,6 +162,58 @@ async def _exchange(client: httpx.AsyncClient, assertion: str) -> dict:
             return step
         token = r.json()["access_token"]
         step.update(status="ok", token=token, decoded=_decode(token))
+    except Exception as exc:  # noqa: BLE001
+        step.update(status="error", error=str(exc))
+    return step
+
+
+async def _gitea_list(client: httpx.AsyncClient, access_token: str) -> dict:
+    step = {
+        "id": "gitea-list",
+        "title": "4. Receiving App reads Gitea (needs gitea:read)",
+        "detail": f"GET {GATEWAY_URL}/api/gitea/repos  (Bearer access token)",
+    }
+    if not access_token:
+        step.update(status="error", error="no access token (run the exchange step first)")
+        return step
+    try:
+        r = await client.get(
+            f"{GATEWAY_URL}/api/gitea/repos",
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        if r.status_code == 200:
+            step.update(status="ok", result=r.json())
+        elif r.status_code == 403:
+            step.update(status="denied", result=r.json())
+        else:
+            step.update(status="error", error=f"HTTP {r.status_code}: {r.text[:300]}")
+    except Exception as exc:  # noqa: BLE001
+        step.update(status="error", error=str(exc))
+    return step
+
+
+async def _gitea_create(client: httpx.AsyncClient, access_token: str, name: str) -> dict:
+    step = {
+        "id": "gitea-create",
+        "title": "5. Receiving App writes to Gitea (needs gitea:write)",
+        "detail": f"POST {GATEWAY_URL}/api/gitea/repos  name={name}  (Bearer access token)",
+    }
+    if not access_token:
+        step.update(status="error", error="no access token (run the exchange step first)")
+        return step
+    try:
+        r = await client.post(
+            f"{GATEWAY_URL}/api/gitea/repos",
+            headers={"Authorization": f"Bearer {access_token}"},
+            json={"name": name},
+        )
+        if r.status_code in (200, 201):
+            step.update(status="ok", result=r.json())
+        elif r.status_code == 403:
+            # Narrow scoping payoff: a read-only token is refused here.
+            step.update(status="denied", result=r.json())
+        else:
+            step.update(status="error", error=f"HTTP {r.status_code}: {r.text[:300]}")
     except Exception as exc:  # noqa: BLE001
         step.update(status="error", error=str(exc))
     return step
@@ -165,12 +234,27 @@ def config():
         "demo_user": DEMO_USER,
         "subject": SUBJECT,
         "issuer": ISSUER_URL,
+        "gateway": GATEWAY_URL,
+        "default_scope": DEFAULT_SCOPE,
     }
 
 
+def _ok(status: str) -> bool:
+    # "denied" (a 403 from the gateway) is an expected outcome for narrow
+    # scoping, not a failure of the sequence.
+    return status in ("ok", "denied")
+
+
+class RunRequest(BaseModel):
+    scope: str = DEFAULT_SCOPE
+    repo_name: str = ""
+
+
 @app.post("/api/run")
-async def run():
-    """Run all three hops in sequence, stopping at the first failure."""
+async def run(body: RunRequest | None = None):
+    """Run the full sequence, stopping only at an unexpected failure."""
+    scope = body.scope if body else DEFAULT_SCOPE
+    repo_name = (body.repo_name if body else "") or _default_repo_name()
     steps: list[dict] = []
     async with httpx.AsyncClient(timeout=15) as client:
         login = await _login(client)
@@ -178,14 +262,38 @@ async def run():
         if login["status"] != "ok":
             return JSONResponse({"ok": False, "steps": steps})
 
-        mint = await _mint(client)
+        mint = await _mint(client, scope)
         steps.append(mint)
         if mint["status"] != "ok":
             return JSONResponse({"ok": False, "steps": steps})
 
-        exchange = await _exchange(client, mint.get("token", ""))
+        exchange = await _exchange(client, mint.get("token", ""), scope)
         steps.append(exchange)
-        return JSONResponse({"ok": exchange["status"] == "ok", "steps": steps})
+        if exchange["status"] != "ok":
+            return JSONResponse({"ok": False, "steps": steps})
+
+        access_token = exchange.get("token", "")
+        gitea_list = await _gitea_list(client, access_token)
+        steps.append(gitea_list)
+
+        gitea_create = await _gitea_create(client, access_token, repo_name)
+        steps.append(gitea_create)
+
+        return JSONResponse({"ok": all(_ok(s["status"]) for s in steps), "steps": steps})
+
+
+class MintRequest(BaseModel):
+    scope: str = DEFAULT_SCOPE
+
+
+class ExchangeRequest(BaseModel):
+    assertion: str
+    scope: str = DEFAULT_SCOPE
+
+
+class GiteaRequest(BaseModel):
+    access_token: str
+    repo_name: str = ""
 
 
 @app.post("/api/step/login")
@@ -196,21 +304,33 @@ async def step_login():
 
 
 @app.post("/api/step/mint")
-async def step_mint():
+async def step_mint(body: MintRequest | None = None):
+    scope = body.scope if body else DEFAULT_SCOPE
     async with httpx.AsyncClient(timeout=15) as client:
-        step = await _mint(client)
+        step = await _mint(client, scope)
     return JSONResponse({"ok": step["status"] == "ok", "step": step})
-
-
-class ExchangeRequest(BaseModel):
-    assertion: str
 
 
 @app.post("/api/step/exchange")
 async def step_exchange(body: ExchangeRequest):
     async with httpx.AsyncClient(timeout=15) as client:
-        step = await _exchange(client, body.assertion)
+        step = await _exchange(client, body.assertion, body.scope)
     return JSONResponse({"ok": step["status"] == "ok", "step": step})
+
+
+@app.post("/api/step/gitea-list")
+async def step_gitea_list(body: GiteaRequest):
+    async with httpx.AsyncClient(timeout=15) as client:
+        step = await _gitea_list(client, body.access_token)
+    return JSONResponse({"ok": _ok(step["status"]), "step": step})
+
+
+@app.post("/api/step/gitea-create")
+async def step_gitea_create(body: GiteaRequest):
+    name = body.repo_name or _default_repo_name()
+    async with httpx.AsyncClient(timeout=15) as client:
+        step = await _gitea_create(client, body.access_token, name)
+    return JSONResponse({"ok": _ok(step["status"]), "step": step})
 
 
 @app.get("/")

--- a/demos/cncf-stack/webapp/app.py
+++ b/demos/cncf-stack/webapp/app.py
@@ -115,10 +115,13 @@ async def run():
             r = await client.post(
                 f"{ISSUER_URL}/mint",
                 json={
+                    # Subject = the end user; actor = the Requesting App acting
+                    # on the user's behalf (RFC 8693 `act`). client_id must match
+                    # the client that presents the assertion (the Receiving App).
                     "sub": SUBJECT,
                     "aud": REALM_ISSUER,
                     "client_id": BACKEND_CLIENT_ID,
-                    "act_chain": [DEMO_USER, BACKEND_CLIENT_ID],
+                    "act_chain": [USER_CLIENT_ID],
                     "scope": "openid",
                 },
             )

--- a/demos/cncf-stack/webapp/app.py
+++ b/demos/cncf-stack/webapp/app.py
@@ -1,0 +1,170 @@
+"""CNCF demo web app — drives the ID-JAG (Cross-App Access) sequence.
+
+All three hops run server-side so the browser never talks to Keycloak or the
+issuer directly (no CORS):
+
+  1. User login       — OIDC password grant against Keycloak (cncf-demo realm)
+  2. Mint ID-JAG       — request a signed assertion from the local issuer
+  3. Receiver exchange — present the assertion to Keycloak's backend-client
+                         token endpoint via the jwt-bearer grant -> access token
+
+The UI shows each hop's status and the decoded token/assertion claims.
+"""
+
+from __future__ import annotations
+
+import os
+
+import httpx
+import jwt as pyjwt
+from fastapi import FastAPI
+from fastapi.responses import FileResponse, JSONResponse
+from fastapi.staticfiles import StaticFiles
+
+KEYCLOAK_URL = os.environ.get("KEYCLOAK_URL", "http://keycloak:8080").rstrip("/")
+REALM = os.environ.get("KEYCLOAK_REALM", "cncf-demo")
+USER_CLIENT_ID = os.environ.get("USER_CLIENT_ID", "cncf-demo-client")
+USER_CLIENT_SECRET = os.environ.get("USER_CLIENT_SECRET", "")
+BACKEND_CLIENT_ID = os.environ.get("BACKEND_CLIENT_ID", "backend-client")
+BACKEND_CLIENT_SECRET = os.environ.get("BACKEND_CLIENT_SECRET", "")
+DEMO_USER = os.environ.get("DEMO_USER", "sarah")
+DEMO_PASSWORD = os.environ.get("DEMO_PASSWORD", "")
+SUBJECT = os.environ.get("IDJAG_SUBJECT", "sarah@enterprisex.com")
+ISSUER_URL = os.environ.get("IDJAG_ISSUER_URL", "http://idjag-issuer:9000").rstrip("/")
+
+TOKEN_ENDPOINT = f"{KEYCLOAK_URL}/realms/{REALM}/protocol/openid-connect/token"
+REALM_ISSUER = f"{KEYCLOAK_URL}/realms/{REALM}"
+
+app = FastAPI(title="CNCF Demo — ID-JAG", version="0.1.0")
+
+_STATIC = os.path.join(os.path.dirname(__file__), "static")
+
+
+def _decode(token: str) -> dict:
+    try:
+        header = pyjwt.get_unverified_header(token)
+        claims = pyjwt.decode(token, options={"verify_signature": False})
+        return {"header": header, "claims": claims}
+    except Exception as exc:  # noqa: BLE001
+        return {"error": f"could not decode: {exc}"}
+
+
+@app.get("/api/health")
+def health():
+    return {"status": "ok"}
+
+
+@app.get("/api/config")
+def config():
+    return {
+        "keycloak": KEYCLOAK_URL,
+        "realm": REALM,
+        "user_client": USER_CLIENT_ID,
+        "backend_client": BACKEND_CLIENT_ID,
+        "demo_user": DEMO_USER,
+        "subject": SUBJECT,
+        "issuer": ISSUER_URL,
+    }
+
+
+@app.post("/api/run")
+async def run():
+    steps: list[dict] = []
+    async with httpx.AsyncClient(timeout=15) as client:
+        # --- Step 1: user login (password grant) ---
+        step = {
+            "id": "login",
+            "title": "1. User login (OIDC password grant)",
+            "detail": f"POST {TOKEN_ENDPOINT}  (client={USER_CLIENT_ID}, user={DEMO_USER})",
+        }
+        try:
+            r = await client.post(
+                TOKEN_ENDPOINT,
+                data={
+                    "grant_type": "password",
+                    "client_id": USER_CLIENT_ID,
+                    "client_secret": USER_CLIENT_SECRET,
+                    "username": DEMO_USER,
+                    "password": DEMO_PASSWORD,
+                    "scope": "openid profile email",
+                },
+            )
+            if r.status_code != 200:
+                step.update(status="error", error=f"HTTP {r.status_code}: {r.text[:300]}")
+                steps.append(step)
+                return JSONResponse({"ok": False, "steps": steps})
+            user_token = r.json()["access_token"]
+            step.update(status="ok", token=user_token, decoded=_decode(user_token))
+            steps.append(step)
+        except Exception as exc:  # noqa: BLE001
+            step.update(status="error", error=str(exc))
+            steps.append(step)
+            return JSONResponse({"ok": False, "steps": steps})
+
+        # --- Step 2: mint ID-JAG assertion at the issuer ---
+        step = {
+            "id": "mint",
+            "title": "2. Mint ID-JAG assertion (external issuer)",
+            "detail": f"POST {ISSUER_URL}/mint  (sub={SUBJECT}, aud={REALM_ISSUER})",
+        }
+        try:
+            r = await client.post(
+                f"{ISSUER_URL}/mint",
+                json={
+                    "sub": SUBJECT,
+                    "aud": REALM_ISSUER,
+                    "client_id": BACKEND_CLIENT_ID,
+                    "act_chain": [DEMO_USER, BACKEND_CLIENT_ID],
+                    "scope": "openid",
+                },
+            )
+            if r.status_code != 200:
+                step.update(status="error", error=f"HTTP {r.status_code}: {r.text[:300]}")
+                steps.append(step)
+                return JSONResponse({"ok": False, "steps": steps})
+            assertion = r.json()["assertion"]
+            step.update(status="ok", token=assertion, decoded=_decode(assertion))
+            steps.append(step)
+        except Exception as exc:  # noqa: BLE001
+            step.update(status="error", error=str(exc))
+            steps.append(step)
+            return JSONResponse({"ok": False, "steps": steps})
+
+        # --- Step 3: receiver exchange (jwt-bearer) ---
+        step = {
+            "id": "exchange",
+            "title": "3. Receiver exchange (Keycloak ID-JAG / jwt-bearer)",
+            "detail": f"POST {TOKEN_ENDPOINT}  (grant_type=jwt-bearer, client={BACKEND_CLIENT_ID})",
+        }
+        try:
+            r = await client.post(
+                TOKEN_ENDPOINT,
+                data={
+                    "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+                    "assertion": assertion,
+                    "client_id": BACKEND_CLIENT_ID,
+                    "client_secret": BACKEND_CLIENT_SECRET,
+                    "scope": "openid",
+                },
+            )
+            if r.status_code != 200:
+                step.update(status="error", error=f"HTTP {r.status_code}: {r.text[:300]}")
+                steps.append(step)
+                return JSONResponse({"ok": False, "steps": steps})
+            access_token = r.json()["access_token"]
+            step.update(status="ok", token=access_token, decoded=_decode(access_token))
+            steps.append(step)
+        except Exception as exc:  # noqa: BLE001
+            step.update(status="error", error=str(exc))
+            steps.append(step)
+            return JSONResponse({"ok": False, "steps": steps})
+
+    return JSONResponse({"ok": True, "steps": steps})
+
+
+@app.get("/")
+def index():
+    return FileResponse(os.path.join(_STATIC, "index.html"))
+
+
+app.mount("/static", StaticFiles(directory=_STATIC), name="static")

--- a/demos/cncf-stack/webapp/app.py
+++ b/demos/cncf-stack/webapp/app.py
@@ -12,7 +12,9 @@ issuer directly (no CORS):
   3. Receiving App exchange — present the assertion to Keycloak's receiving-app token
                           endpoint via the jwt-bearer grant -> access token
 
-The UI shows each hop's status and the decoded token/assertion claims.
+Each hop is exposed both as part of /api/run (all three at once) and as an
+individual /api/step/<id> endpoint, so the UI can either animate the sequence
+or let the presenter step through it one hop at a time.
 """
 
 from __future__ import annotations
@@ -23,6 +25,7 @@ import httpx
 import jwt as pyjwt
 from fastapi import FastAPI
 from fastapi.responses import FileResponse, JSONResponse
+from pydantic import BaseModel
 from fastapi.staticfiles import StaticFiles
 
 KEYCLOAK_URL = os.environ.get("KEYCLOAK_URL", "http://keycloak:8080").rstrip("/")
@@ -53,6 +56,100 @@ def _decode(token: str) -> dict:
         return {"error": f"could not decode: {exc}"}
 
 
+# --- individual hops -------------------------------------------------------
+# Each returns a "step" dict with status ok/error. On success it also carries
+# the raw `token` (the access token, or the assertion for the mint step) so the
+# next hop / the caller can reuse it.
+
+
+async def _login(client: httpx.AsyncClient) -> dict:
+    step = {
+        "id": "login",
+        "title": "1. Requesting App — user sign-in (OIDC password grant)",
+        "detail": f"POST {TOKEN_ENDPOINT}  (client={USER_CLIENT_ID}, user={DEMO_USER})",
+    }
+    try:
+        r = await client.post(
+            TOKEN_ENDPOINT,
+            data={
+                "grant_type": "password",
+                "client_id": USER_CLIENT_ID,
+                "client_secret": USER_CLIENT_SECRET,
+                "username": DEMO_USER,
+                "password": DEMO_PASSWORD,
+                "scope": "openid profile email",
+            },
+        )
+        if r.status_code != 200:
+            step.update(status="error", error=f"HTTP {r.status_code}: {r.text[:300]}")
+            return step
+        token = r.json()["access_token"]
+        step.update(status="ok", token=token, decoded=_decode(token))
+    except Exception as exc:  # noqa: BLE001
+        step.update(status="error", error=str(exc))
+    return step
+
+
+async def _mint(client: httpx.AsyncClient) -> dict:
+    step = {
+        "id": "mint",
+        "title": "2. Mint ID-JAG assertion (for the Receiving App)",
+        "detail": f"POST {ISSUER_URL}/mint  (sub={SUBJECT}, aud={REALM_ISSUER})",
+    }
+    try:
+        r = await client.post(
+            f"{ISSUER_URL}/mint",
+            json={
+                # Subject = the end user; actor = the Requesting App acting
+                # on the user's behalf (RFC 8693 `act`). client_id must match
+                # the client that presents the assertion (the Receiving App).
+                "sub": SUBJECT,
+                "aud": REALM_ISSUER,
+                "client_id": BACKEND_CLIENT_ID,
+                "act_chain": [USER_CLIENT_ID],
+                "scope": "openid",
+            },
+        )
+        if r.status_code != 200:
+            step.update(status="error", error=f"HTTP {r.status_code}: {r.text[:300]}")
+            return step
+        assertion = r.json()["assertion"]
+        step.update(status="ok", token=assertion, decoded=_decode(assertion))
+    except Exception as exc:  # noqa: BLE001
+        step.update(status="error", error=str(exc))
+    return step
+
+
+async def _exchange(client: httpx.AsyncClient, assertion: str) -> dict:
+    step = {
+        "id": "exchange",
+        "title": "3. Receiving App — exchange (Keycloak ID-JAG / jwt-bearer)",
+        "detail": f"POST {TOKEN_ENDPOINT}  (grant_type=jwt-bearer, client={BACKEND_CLIENT_ID})",
+    }
+    if not assertion:
+        step.update(status="error", error="no assertion provided (run the mint step first)")
+        return step
+    try:
+        r = await client.post(
+            TOKEN_ENDPOINT,
+            data={
+                "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+                "assertion": assertion,
+                "client_id": BACKEND_CLIENT_ID,
+                "client_secret": BACKEND_CLIENT_SECRET,
+                "scope": "openid",
+            },
+        )
+        if r.status_code != 200:
+            step.update(status="error", error=f"HTTP {r.status_code}: {r.text[:300]}")
+            return step
+        token = r.json()["access_token"]
+        step.update(status="ok", token=token, decoded=_decode(token))
+    except Exception as exc:  # noqa: BLE001
+        step.update(status="error", error=str(exc))
+    return step
+
+
 @app.get("/api/health")
 def health():
     return {"status": "ok"}
@@ -73,100 +170,47 @@ def config():
 
 @app.post("/api/run")
 async def run():
+    """Run all three hops in sequence, stopping at the first failure."""
     steps: list[dict] = []
     async with httpx.AsyncClient(timeout=15) as client:
-        # --- Step 1: user login (password grant) ---
-        step = {
-            "id": "login",
-            "title": "1. Requesting App — user sign-in (OIDC password grant)",
-            "detail": f"POST {TOKEN_ENDPOINT}  (client={USER_CLIENT_ID}, user={DEMO_USER})",
-        }
-        try:
-            r = await client.post(
-                TOKEN_ENDPOINT,
-                data={
-                    "grant_type": "password",
-                    "client_id": USER_CLIENT_ID,
-                    "client_secret": USER_CLIENT_SECRET,
-                    "username": DEMO_USER,
-                    "password": DEMO_PASSWORD,
-                    "scope": "openid profile email",
-                },
-            )
-            if r.status_code != 200:
-                step.update(status="error", error=f"HTTP {r.status_code}: {r.text[:300]}")
-                steps.append(step)
-                return JSONResponse({"ok": False, "steps": steps})
-            user_token = r.json()["access_token"]
-            step.update(status="ok", token=user_token, decoded=_decode(user_token))
-            steps.append(step)
-        except Exception as exc:  # noqa: BLE001
-            step.update(status="error", error=str(exc))
-            steps.append(step)
+        login = await _login(client)
+        steps.append(login)
+        if login["status"] != "ok":
             return JSONResponse({"ok": False, "steps": steps})
 
-        # --- Step 2: mint ID-JAG assertion at the issuer ---
-        step = {
-            "id": "mint",
-            "title": "2. Mint ID-JAG assertion (for the Receiving App)",
-            "detail": f"POST {ISSUER_URL}/mint  (sub={SUBJECT}, aud={REALM_ISSUER})",
-        }
-        try:
-            r = await client.post(
-                f"{ISSUER_URL}/mint",
-                json={
-                    # Subject = the end user; actor = the Requesting App acting
-                    # on the user's behalf (RFC 8693 `act`). client_id must match
-                    # the client that presents the assertion (the Receiving App).
-                    "sub": SUBJECT,
-                    "aud": REALM_ISSUER,
-                    "client_id": BACKEND_CLIENT_ID,
-                    "act_chain": [USER_CLIENT_ID],
-                    "scope": "openid",
-                },
-            )
-            if r.status_code != 200:
-                step.update(status="error", error=f"HTTP {r.status_code}: {r.text[:300]}")
-                steps.append(step)
-                return JSONResponse({"ok": False, "steps": steps})
-            assertion = r.json()["assertion"]
-            step.update(status="ok", token=assertion, decoded=_decode(assertion))
-            steps.append(step)
-        except Exception as exc:  # noqa: BLE001
-            step.update(status="error", error=str(exc))
-            steps.append(step)
+        mint = await _mint(client)
+        steps.append(mint)
+        if mint["status"] != "ok":
             return JSONResponse({"ok": False, "steps": steps})
 
-        # --- Step 3: receiver exchange (jwt-bearer) ---
-        step = {
-            "id": "exchange",
-            "title": "3. Receiving App — exchange (Keycloak ID-JAG / jwt-bearer)",
-            "detail": f"POST {TOKEN_ENDPOINT}  (grant_type=jwt-bearer, client={BACKEND_CLIENT_ID})",
-        }
-        try:
-            r = await client.post(
-                TOKEN_ENDPOINT,
-                data={
-                    "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
-                    "assertion": assertion,
-                    "client_id": BACKEND_CLIENT_ID,
-                    "client_secret": BACKEND_CLIENT_SECRET,
-                    "scope": "openid",
-                },
-            )
-            if r.status_code != 200:
-                step.update(status="error", error=f"HTTP {r.status_code}: {r.text[:300]}")
-                steps.append(step)
-                return JSONResponse({"ok": False, "steps": steps})
-            access_token = r.json()["access_token"]
-            step.update(status="ok", token=access_token, decoded=_decode(access_token))
-            steps.append(step)
-        except Exception as exc:  # noqa: BLE001
-            step.update(status="error", error=str(exc))
-            steps.append(step)
-            return JSONResponse({"ok": False, "steps": steps})
+        exchange = await _exchange(client, mint.get("token", ""))
+        steps.append(exchange)
+        return JSONResponse({"ok": exchange["status"] == "ok", "steps": steps})
 
-    return JSONResponse({"ok": True, "steps": steps})
+
+@app.post("/api/step/login")
+async def step_login():
+    async with httpx.AsyncClient(timeout=15) as client:
+        step = await _login(client)
+    return JSONResponse({"ok": step["status"] == "ok", "step": step})
+
+
+@app.post("/api/step/mint")
+async def step_mint():
+    async with httpx.AsyncClient(timeout=15) as client:
+        step = await _mint(client)
+    return JSONResponse({"ok": step["status"] == "ok", "step": step})
+
+
+class ExchangeRequest(BaseModel):
+    assertion: str
+
+
+@app.post("/api/step/exchange")
+async def step_exchange(body: ExchangeRequest):
+    async with httpx.AsyncClient(timeout=15) as client:
+        step = await _exchange(client, body.assertion)
+    return JSONResponse({"ok": step["status"] == "ok", "step": step})
 
 
 @app.get("/")

--- a/demos/cncf-stack/webapp/app.py
+++ b/demos/cncf-stack/webapp/app.py
@@ -1,12 +1,16 @@
 """CNCF demo web app — drives the ID-JAG (Cross-App Access) sequence.
 
+Cross-App Access lets the **Requesting App** obtain access to the
+**Receiving App** on behalf of a signed-in user, without the Receiving App
+ever seeing the user's password.
+
 All three hops run server-side so the browser never talks to Keycloak or the
 issuer directly (no CORS):
 
-  1. User login       — OIDC password grant against Keycloak (cncf-demo realm)
-  2. Mint ID-JAG       — request a signed assertion from the local issuer
-  3. Receiver exchange — present the assertion to Keycloak's backend-client
-                         token endpoint via the jwt-bearer grant -> access token
+  1. Requesting App login — OIDC password grant against Keycloak (cncf-demo realm)
+  2. Mint ID-JAG          — request a signed assertion (for the Receiving App) from the issuer
+  3. Receiving App exchange — present the assertion to Keycloak's receiving-app token
+                          endpoint via the jwt-bearer grant -> access token
 
 The UI shows each hop's status and the decoded token/assertion claims.
 """
@@ -23,13 +27,13 @@ from fastapi.staticfiles import StaticFiles
 
 KEYCLOAK_URL = os.environ.get("KEYCLOAK_URL", "http://keycloak:8080").rstrip("/")
 REALM = os.environ.get("KEYCLOAK_REALM", "cncf-demo")
-USER_CLIENT_ID = os.environ.get("USER_CLIENT_ID", "cncf-demo-client")
+USER_CLIENT_ID = os.environ.get("USER_CLIENT_ID", "requesting-app")
 USER_CLIENT_SECRET = os.environ.get("USER_CLIENT_SECRET", "")
-BACKEND_CLIENT_ID = os.environ.get("BACKEND_CLIENT_ID", "backend-client")
+BACKEND_CLIENT_ID = os.environ.get("BACKEND_CLIENT_ID", "receiving-app")
 BACKEND_CLIENT_SECRET = os.environ.get("BACKEND_CLIENT_SECRET", "")
-DEMO_USER = os.environ.get("DEMO_USER", "sarah")
+DEMO_USER = os.environ.get("DEMO_USER", "user")
 DEMO_PASSWORD = os.environ.get("DEMO_PASSWORD", "")
-SUBJECT = os.environ.get("IDJAG_SUBJECT", "sarah@enterprisex.com")
+SUBJECT = os.environ.get("IDJAG_SUBJECT", "user@example.com")
 ISSUER_URL = os.environ.get("IDJAG_ISSUER_URL", "http://idjag-issuer:9000").rstrip("/")
 
 TOKEN_ENDPOINT = f"{KEYCLOAK_URL}/realms/{REALM}/protocol/openid-connect/token"
@@ -74,7 +78,7 @@ async def run():
         # --- Step 1: user login (password grant) ---
         step = {
             "id": "login",
-            "title": "1. User login (OIDC password grant)",
+            "title": "1. Requesting App — user sign-in (OIDC password grant)",
             "detail": f"POST {TOKEN_ENDPOINT}  (client={USER_CLIENT_ID}, user={DEMO_USER})",
         }
         try:
@@ -104,7 +108,7 @@ async def run():
         # --- Step 2: mint ID-JAG assertion at the issuer ---
         step = {
             "id": "mint",
-            "title": "2. Mint ID-JAG assertion (external issuer)",
+            "title": "2. Mint ID-JAG assertion (for the Receiving App)",
             "detail": f"POST {ISSUER_URL}/mint  (sub={SUBJECT}, aud={REALM_ISSUER})",
         }
         try:
@@ -133,7 +137,7 @@ async def run():
         # --- Step 3: receiver exchange (jwt-bearer) ---
         step = {
             "id": "exchange",
-            "title": "3. Receiver exchange (Keycloak ID-JAG / jwt-bearer)",
+            "title": "3. Receiving App — exchange (Keycloak ID-JAG / jwt-bearer)",
             "detail": f"POST {TOKEN_ENDPOINT}  (grant_type=jwt-bearer, client={BACKEND_CLIENT_ID})",
         }
         try:

--- a/demos/cncf-stack/webapp/requirements-dev.txt
+++ b/demos/cncf-stack/webapp/requirements-dev.txt
@@ -1,0 +1,4 @@
+-r requirements.txt
+pytest
+# Mocks the outbound httpx calls to Keycloak / the ID-JAG issuer.
+respx

--- a/demos/cncf-stack/webapp/requirements.txt
+++ b/demos/cncf-stack/webapp/requirements.txt
@@ -1,0 +1,4 @@
+fastapi==0.115.6
+uvicorn==0.34.0
+httpx==0.28.1
+pyjwt==2.10.1

--- a/demos/cncf-stack/webapp/static/index.html
+++ b/demos/cncf-stack/webapp/static/index.html
@@ -50,6 +50,22 @@
     }
     .err-msg { color: var(--err); padding: 0 16px 14px; font-family: ui-monospace, monospace; font-size: 12px; }
     .flow { color: var(--muted); font-size: 13px; margin-bottom: 8px; }
+    .diagram {
+      background: var(--panel); border: 1px solid var(--border); border-radius: 8px;
+      padding: 16px; margin-bottom: 20px; overflow-x: auto;
+    }
+    .diagram svg { width: 100%; min-width: 620px; height: auto; display: block; }
+    .seq-actor-box { fill: #21262d; stroke: var(--border); }
+    .seq-actor { fill: var(--text); font-size: 13px; font-weight: 600; }
+    .seq-life { stroke: var(--border); stroke-dasharray: 4 4; }
+    /* message groups — colored by step status */
+    .g .seq-msg { stroke: var(--muted); stroke-width: 1.6; }
+    .g .seq-msg.ret { stroke-dasharray: 6 4; }
+    .g .seq-label { fill: var(--muted); font-size: 12px; }
+    .g .seq-num { fill: var(--muted); font-size: 12px; font-weight: 700; }
+    .g.running .seq-msg { stroke: var(--run); } .g.running .seq-label, .g.running .seq-num { fill: var(--run); }
+    .g.ok .seq-msg { stroke: var(--ok); } .g.ok .seq-label, .g.ok .seq-num { fill: var(--ok); }
+    .g.error .seq-msg { stroke: var(--err); } .g.error .seq-label, .g.error .seq-num { fill: var(--err); }
   </style>
 </head>
 <body>
@@ -63,6 +79,58 @@
   <main>
     <div class="config" id="config"></div>
     <div class="flow">The Requesting App gets access to the Receiving App on the user's behalf. Three server-side hops &mdash; each card shows the decoded JWT header + claims.</div>
+
+    <div class="diagram">
+      <svg viewBox="0 0 860 340" role="img" aria-label="ID-JAG cross-app access sequence diagram">
+        <defs>
+          <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+            <path d="M0,0 L10,5 L0,10 z" fill="context-stroke" />
+          </marker>
+        </defs>
+
+        <!-- actors -->
+        <g>
+          <rect class="seq-actor-box" x="60"  y="10" width="160" height="30" rx="5" />
+          <text class="seq-actor" x="140" y="30" text-anchor="middle">Requesting App</text>
+          <rect class="seq-actor-box" x="350" y="10" width="160" height="30" rx="5" />
+          <text class="seq-actor" x="430" y="30" text-anchor="middle">ID-JAG Issuer</text>
+          <rect class="seq-actor-box" x="640" y="10" width="180" height="30" rx="5" />
+          <text class="seq-actor" x="730" y="30" text-anchor="middle">Keycloak / Receiving App</text>
+          <!-- lifelines -->
+          <line class="seq-life" x1="140" y1="40" x2="140" y2="330" />
+          <line class="seq-life" x1="430" y1="40" x2="430" y2="330" />
+          <line class="seq-life" x1="730" y1="40" x2="730" y2="330" />
+        </g>
+
+        <!-- 1. sign in -->
+        <g data-step="login" class="g">
+          <text class="seq-num"   x="150" y="82">1</text>
+          <text class="seq-label" x="168" y="82">User sign-in — password grant</text>
+          <line class="seq-msg"      x1="140" y1="90"  x2="730" y2="90"  marker-end="url(#arrow)" />
+          <text class="seq-label" x="722" y="118" text-anchor="end">user access token</text>
+          <line class="seq-msg ret"  x1="730" y1="126" x2="140" y2="126" marker-end="url(#arrow)" />
+        </g>
+
+        <!-- 2. mint -->
+        <g data-step="mint" class="g">
+          <text class="seq-num"   x="150" y="162">2</text>
+          <text class="seq-label" x="168" y="162">Mint ID-JAG (sub = user, act = Requesting App)</text>
+          <line class="seq-msg"      x1="140" y1="170" x2="430" y2="170" marker-end="url(#arrow)" />
+          <text class="seq-label" x="422" y="198" text-anchor="end">signed assertion</text>
+          <line class="seq-msg ret"  x1="430" y1="206" x2="140" y2="206" marker-end="url(#arrow)" />
+        </g>
+
+        <!-- 3. exchange -->
+        <g data-step="exchange" class="g">
+          <text class="seq-num"   x="150" y="242">3</text>
+          <text class="seq-label" x="168" y="242">jwt-bearer exchange (assertion)</text>
+          <line class="seq-msg"      x1="140" y1="250" x2="730" y2="250" marker-end="url(#arrow)" />
+          <text class="seq-label" x="722" y="278" text-anchor="end">Receiving App access token</text>
+          <line class="seq-msg ret"  x1="730" y1="286" x2="140" y2="286" marker-end="url(#arrow)" />
+        </g>
+      </svg>
+    </div>
+
     <div id="steps"></div>
   </main>
 
@@ -99,6 +167,16 @@
       return String(s).replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
     }
 
+    function updateDiagram(steps) {
+      const byId = Object.fromEntries(steps.map(s => [s.id, s]));
+      TEMPLATE.forEach(t => {
+        const g = document.querySelector(`[data-step="${t.id}"]`);
+        if (g) g.setAttribute('class', 'g ' + ((byId[t.id] && byId[t.id].status) || 'pending'));
+      });
+    }
+
+    function setStates(steps) { render(steps); updateDiagram(steps); }
+
     async function loadConfig() {
       try {
         const c = await (await fetch('/api/config')).json();
@@ -108,26 +186,27 @@
            <div><b>Requesting App:</b> ${escapeHtml(c.user_client)}</div>
            <div><b>Receiving App:</b> ${escapeHtml(c.backend_client)}</div>
            <div><b>Demo user:</b> ${escapeHtml(c.demo_user)}</div>
+           <div><b>Subject:</b> ${escapeHtml(c.subject)}</div>
            <div><b>ID-JAG issuer:</b> ${escapeHtml(c.issuer)}</div>`;
       } catch (e) { /* ignore */ }
     }
 
     runBtn.addEventListener('click', async () => {
       runBtn.disabled = true;
-      render(TEMPLATE.map(t => ({ id: t.id, status: 'running' })));
+      setStates(TEMPLATE.map(t => ({ id: t.id, status: 'running' })));
       try {
         const res = await fetch('/api/run', { method: 'POST' });
         const data = await res.json();
-        render(data.steps);
+        setStates(data.steps);
       } catch (e) {
-        render([{ id: 'login', status: 'error', error: String(e) }]);
+        setStates([{ id: 'login', status: 'error', error: String(e) }]);
       } finally {
         runBtn.disabled = false;
       }
     });
 
     loadConfig();
-    render(TEMPLATE.map(t => ({ id: t.id, status: 'pending' })));
+    setStates(TEMPLATE.map(t => ({ id: t.id, status: 'pending' })));
   </script>
 </body>
 </html>

--- a/demos/cncf-stack/webapp/static/index.html
+++ b/demos/cncf-stack/webapp/static/index.html
@@ -9,6 +9,7 @@
       --bg: #0d1117; --panel: #161b22; --border: #30363d;
       --text: #e6edf3; --muted: #8b949e; --accent: #2f81f7;
       --ok: #3fb950; --err: #f85149; --run: #d29922; --denied: #db8f2f;
+      --teal: #39c5cf; --purple: #bc8cff;
     }
     * { box-sizing: border-box; }
     body {
@@ -21,17 +22,24 @@
     }
     header h1 { font-size: 20px; margin: 0; }
     header .sub { color: var(--muted); font-size: 13px; margin-top: 4px; }
-    main { max-width: 960px; margin: 0 auto; padding: 24px 32px; }
+    main { max-width: 980px; margin: 0 auto; padding: 24px 32px; }
+    .tabs { display: flex; gap: 4px; }
+    .tab {
+      background: transparent; color: var(--muted); border: 1px solid var(--border);
+      border-radius: 8px; padding: 9px 16px; font-size: 14px; font-weight: 600; cursor: pointer;
+    }
+    .tab.active { background: var(--panel); color: var(--text); border-color: var(--accent); }
     .config { font-size: 12px; color: var(--muted); background: var(--panel);
       border: 1px solid var(--border); border-radius: 8px; padding: 12px 16px; margin-bottom: 20px;
       display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 4px 20px; }
     .config b { color: var(--text); font-weight: 600; }
-    .controls { display: flex; gap: 8px; flex-wrap: wrap; }
-    button {
+    .controls { display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 18px; }
+    button.action {
       background: var(--accent); color: white; border: 0; border-radius: 6px;
       padding: 10px 18px; font-size: 14px; font-weight: 600; cursor: pointer;
     }
-    button.secondary { background: #21262d; color: var(--text); border: 1px solid var(--border); }
+    button.secondary { background: #21262d; color: var(--text); border: 1px solid var(--border);
+      border-radius: 6px; padding: 10px 18px; font-size: 14px; font-weight: 600; cursor: pointer; }
     button:disabled { opacity: 0.55; cursor: default; }
     .step {
       background: var(--panel); border: 1px solid var(--border); border-radius: 8px;
@@ -67,7 +75,7 @@
     .seq-actor-box { fill: #21262d; stroke: var(--border); }
     .seq-actor { fill: var(--text); font-size: 13px; font-weight: 600; }
     .seq-life { stroke: var(--border); stroke-dasharray: 4 4; }
-    /* message groups — colored by step status */
+    /* message groups — colored by step status (live demo) */
     .g .seq-msg { stroke: var(--muted); stroke-width: 1.6; }
     .g .seq-msg.ret { stroke-dasharray: 6 4; }
     .g .seq-label { fill: var(--muted); font-size: 12px; }
@@ -76,107 +84,444 @@
     .g.ok .seq-msg { stroke: var(--ok); } .g.ok .seq-label, .g.ok .seq-num { fill: var(--ok); }
     .g.error .seq-msg { stroke: var(--err); } .g.error .seq-label, .g.error .seq-num { fill: var(--err); }
     .g.denied .seq-msg { stroke: var(--denied); } .g.denied .seq-label, .g.denied .seq-num { fill: var(--denied); }
+    /* static (documentation) diagrams */
+    .diagram.doc .seq-msg { stroke: var(--accent); stroke-width: 1.6; }
+    .diagram.doc .seq-msg.ret { stroke: var(--muted); stroke-dasharray: 6 4; }
+    .diagram.doc .seq-msg.alt { stroke: var(--purple); }
+    .diagram.doc .seq-label { fill: #c9d1d9; font-size: 12px; }
+    .diagram.doc .seq-num { fill: var(--accent); font-size: 12px; font-weight: 700; }
+    .diagram.doc .seq-note { fill: var(--muted); font-size: 11px; font-style: italic; }
+    /* prose (How it works) */
+    .prose h2 { font-size: 18px; margin: 30px 0 6px; }
+    .prose h3 { font-size: 15px; margin: 22px 0 4px; color: var(--text); }
+    .prose p { color: #c9d1d9; font-size: 14px; margin: 8px 0; }
+    .prose ul { color: #c9d1d9; font-size: 14px; margin: 8px 0; padding-left: 22px; }
+    .prose li { margin: 4px 0; }
+    .prose code { background: #0b0f14; border: 1px solid var(--border); border-radius: 4px;
+      padding: 1px 5px; font-size: 12px; color: var(--teal); }
+    .prose pre { border: 1px solid var(--border); border-radius: 8px; margin: 10px 0; }
+    .prose pre code { background: none; border: 0; padding: 0; color: #c9d1d9; }
+    .prose table { border-collapse: collapse; width: 100%; margin: 10px 0; font-size: 13px; }
+    .prose th, .prose td { border: 1px solid var(--border); padding: 7px 10px; text-align: left; vertical-align: top; }
+    .prose th { background: var(--panel); color: var(--text); }
+    .caption { color: var(--muted); font-size: 12px; margin: -8px 0 18px; }
+    .tag { font-size: 10px; font-weight: 700; text-transform: uppercase; padding: 2px 7px; border-radius: 20px; vertical-align: middle; margin-left: 8px; }
+    .tag.live { background: rgba(63,185,80,.15); color: var(--ok); }
+    .tag.today { background: rgba(47,129,247,.15); color: var(--accent); }
+    .tag.proposed { background: rgba(188,140,255,.16); color: var(--purple); }
+    .note { background: rgba(47,129,247,.08); border: 1px solid rgba(47,129,247,.35);
+      border-radius: 8px; padding: 12px 16px; margin: 14px 0; font-size: 13px; color: #c9d1d9; }
+    [hidden] { display: none !important; }
   </style>
 </head>
 <body>
   <header>
     <div>
-      <h1>Cross-App Access &mdash; Requesting App &rarr; Receiving App &rarr; Gitea</h1>
-      <div class="sub">ID-JAG issuer &rarr; Keycloak 26.7 receiver (<code>jwt-bearer</code>) &rarr; scoped access token &rarr; Gitea via gateway</div>
+      <h1>AGNTCY Identity &mdash; Cross-App Access (ID-JAG)</h1>
+      <div class="sub">Requesting App &rarr; ID-JAG issuer &rarr; Keycloak 26.7 receiver (<code>jwt-bearer</code>) &rarr; scoped token &rarr; Gitea</div>
     </div>
-    <div class="controls">
-      <button id="run">Run (animated)</button>
-      <button id="step" class="secondary">Next step &#9654;</button>
-      <button id="reset" class="secondary" disabled>Reset</button>
-    </div>
+    <nav class="tabs">
+      <button class="tab active" data-tab="demo">Live demo</button>
+      <button class="tab" data-tab="how">How it works</button>
+    </nav>
   </header>
+
   <main>
-    <div class="config" id="config"></div>
+    <!-- ============================ LIVE DEMO ============================ -->
+    <section id="tab-demo">
+      <div class="controls">
+        <button id="run" class="action">Run (animated)</button>
+        <button id="step" class="secondary">Next step &#9654;</button>
+        <button id="reset" class="secondary" disabled>Reset</button>
+      </div>
 
-    <div class="scope-pick">
-      <span><b>Requested scope:</b></span>
-      <label><input type="radio" name="scope" value="openid gitea:read" checked> Read-only <code>gitea:read</code></label>
-      <label><input type="radio" name="scope" value="openid gitea:read gitea:write"> Read + write <code>gitea:read gitea:write</code></label>
-    </div>
+      <div class="config" id="config"></div>
 
-    <div class="flow">The Requesting App gets access to the Receiving App on the user's behalf, then the Receiving App calls Gitea with the exchanged token. The gateway enforces the requested scope: with <b>read-only</b>, listing repos succeeds but creating one is <b>denied (403)</b> — narrow scoping in action. <b>Run (animated)</b> plays all hops with a pause between each; <b>Next step</b> runs them one at a time.</div>
+      <div class="scope-pick">
+        <span><b>Requested scope:</b></span>
+        <label><input type="radio" name="scope" value="openid gitea:read" checked> Read-only <code>gitea:read</code></label>
+        <label><input type="radio" name="scope" value="openid gitea:read gitea:write"> Read + write <code>gitea:read gitea:write</code></label>
+      </div>
 
-    <div class="diagram">
-      <svg viewBox="0 0 1000 480" role="img" aria-label="ID-JAG cross-app access with Gitea narrow scoping sequence diagram">
-        <defs>
-          <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
-            <path d="M0,0 L10,5 L0,10 z" fill="context-stroke" />
-          </marker>
-        </defs>
+      <div class="flow">The Requesting App gets access to the Receiving App on the user's behalf, then the Receiving App calls Gitea with the exchanged token. The gateway enforces the requested scope: with <b>read-only</b>, listing repos succeeds but creating one is <b>denied (403)</b> — narrow scoping in action. <b>Run (animated)</b> plays all hops with a pause between each; <b>Next step</b> runs them one at a time.</div>
 
-        <!-- actors -->
-        <g>
-          <rect class="seq-actor-box" x="45"  y="10" width="150" height="30" rx="5" />
-          <text class="seq-actor" x="120" y="30" text-anchor="middle">Requesting App</text>
-          <rect class="seq-actor-box" x="305" y="10" width="150" height="30" rx="5" />
-          <text class="seq-actor" x="380" y="30" text-anchor="middle">ID-JAG Issuer</text>
-          <rect class="seq-actor-box" x="560" y="10" width="170" height="30" rx="5" />
-          <text class="seq-actor" x="645" y="30" text-anchor="middle">Keycloak / Receiving</text>
-          <rect class="seq-actor-box" x="830" y="10" width="150" height="30" rx="5" />
-          <text class="seq-actor" x="905" y="30" text-anchor="middle">Gitea (gateway)</text>
-          <!-- lifelines -->
-          <line class="seq-life" x1="120" y1="40" x2="120" y2="470" />
-          <line class="seq-life" x1="380" y1="40" x2="380" y2="470" />
-          <line class="seq-life" x1="645" y1="40" x2="645" y2="470" />
-          <line class="seq-life" x1="905" y1="40" x2="905" y2="470" />
-        </g>
+      <div class="diagram">
+        <svg viewBox="0 0 1000 480" role="img" aria-label="ID-JAG cross-app access with Gitea narrow scoping sequence diagram">
+          <defs>
+            <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+              <path d="M0,0 L10,5 L0,10 z" fill="context-stroke" />
+            </marker>
+          </defs>
 
-        <!-- 1. sign in -->
-        <g data-step="login" class="g">
-          <text class="seq-num"   x="130" y="82">1</text>
-          <text class="seq-label" x="148" y="82">User sign-in — password grant</text>
-          <line class="seq-msg"      x1="120" y1="90"  x2="645" y2="90"  marker-end="url(#arrow)" />
-          <text class="seq-label" x="637" y="118" text-anchor="end">user access token</text>
-          <line class="seq-msg ret"  x1="645" y1="126" x2="120" y2="126" marker-end="url(#arrow)" />
-        </g>
+          <g>
+            <rect class="seq-actor-box" x="45"  y="10" width="150" height="30" rx="5" />
+            <text class="seq-actor" x="120" y="30" text-anchor="middle">Requesting App</text>
+            <rect class="seq-actor-box" x="305" y="10" width="150" height="30" rx="5" />
+            <text class="seq-actor" x="380" y="30" text-anchor="middle">ID-JAG Issuer</text>
+            <rect class="seq-actor-box" x="560" y="10" width="170" height="30" rx="5" />
+            <text class="seq-actor" x="645" y="30" text-anchor="middle">Keycloak / Receiving</text>
+            <rect class="seq-actor-box" x="830" y="10" width="150" height="30" rx="5" />
+            <text class="seq-actor" x="905" y="30" text-anchor="middle">Gitea (gateway)</text>
+            <line class="seq-life" x1="120" y1="40" x2="120" y2="470" />
+            <line class="seq-life" x1="380" y1="40" x2="380" y2="470" />
+            <line class="seq-life" x1="645" y1="40" x2="645" y2="470" />
+            <line class="seq-life" x1="905" y1="40" x2="905" y2="470" />
+          </g>
 
-        <!-- 2. mint -->
-        <g data-step="mint" class="g">
-          <text class="seq-num"   x="130" y="162">2</text>
-          <text class="seq-label" x="148" y="162">Mint ID-JAG (sub = user, act = Requesting App, scope)</text>
-          <line class="seq-msg"      x1="120" y1="170" x2="380" y2="170" marker-end="url(#arrow)" />
-          <text class="seq-label" x="372" y="198" text-anchor="end">signed assertion</text>
-          <line class="seq-msg ret"  x1="380" y1="206" x2="120" y2="206" marker-end="url(#arrow)" />
-        </g>
+          <g data-step="login" class="g">
+            <text class="seq-num"   x="130" y="82">1</text>
+            <text class="seq-label" x="148" y="82">User sign-in — password grant</text>
+            <line class="seq-msg"      x1="120" y1="90"  x2="645" y2="90"  marker-end="url(#arrow)" />
+            <text class="seq-label" x="637" y="118" text-anchor="end">user access token</text>
+            <line class="seq-msg ret"  x1="645" y1="126" x2="120" y2="126" marker-end="url(#arrow)" />
+          </g>
 
-        <!-- 3. exchange -->
-        <g data-step="exchange" class="g">
-          <text class="seq-num"   x="130" y="242">3</text>
-          <text class="seq-label" x="148" y="242">jwt-bearer exchange (assertion + requested scope)</text>
-          <line class="seq-msg"      x1="120" y1="250" x2="645" y2="250" marker-end="url(#arrow)" />
-          <text class="seq-label" x="637" y="278" text-anchor="end">downscoped access token</text>
-          <line class="seq-msg ret"  x1="645" y1="286" x2="120" y2="286" marker-end="url(#arrow)" />
-        </g>
+          <g data-step="mint" class="g">
+            <text class="seq-num"   x="130" y="162">2</text>
+            <text class="seq-label" x="148" y="162">Mint ID-JAG (sub = user, act = Requesting App, scope)</text>
+            <line class="seq-msg"      x1="120" y1="170" x2="380" y2="170" marker-end="url(#arrow)" />
+            <text class="seq-label" x="372" y="198" text-anchor="end">signed assertion</text>
+            <line class="seq-msg ret"  x1="380" y1="206" x2="120" y2="206" marker-end="url(#arrow)" />
+          </g>
 
-        <!-- 4. gitea read -->
-        <g data-step="gitea-list" class="g">
-          <text class="seq-num"   x="130" y="322">4</text>
-          <text class="seq-label" x="148" y="322">GET repos — Bearer token (needs gitea:read)</text>
-          <line class="seq-msg"      x1="120" y1="330" x2="905" y2="330" marker-end="url(#arrow)" />
-          <text class="seq-label" x="897" y="358" text-anchor="end">repo list</text>
-          <line class="seq-msg ret"  x1="905" y1="366" x2="120" y2="366" marker-end="url(#arrow)" />
-        </g>
+          <g data-step="exchange" class="g">
+            <text class="seq-num"   x="130" y="242">3</text>
+            <text class="seq-label" x="148" y="242">jwt-bearer exchange (assertion + requested scope)</text>
+            <line class="seq-msg"      x1="120" y1="250" x2="645" y2="250" marker-end="url(#arrow)" />
+            <text class="seq-label" x="637" y="278" text-anchor="end">downscoped access token</text>
+            <line class="seq-msg ret"  x1="645" y1="286" x2="120" y2="286" marker-end="url(#arrow)" />
+          </g>
 
-        <!-- 5. gitea write -->
-        <g data-step="gitea-create" class="g">
-          <text class="seq-num"   x="130" y="402">5</text>
-          <text class="seq-label" x="148" y="402">POST repo — Bearer token (needs gitea:write)</text>
-          <line class="seq-msg"      x1="120" y1="410" x2="905" y2="410" marker-end="url(#arrow)" />
-          <text class="seq-label" x="897" y="438" text-anchor="end">created — or 403 denied if read-only</text>
-          <line class="seq-msg ret"  x1="905" y1="446" x2="120" y2="446" marker-end="url(#arrow)" />
-        </g>
-      </svg>
-    </div>
+          <g data-step="gitea-list" class="g">
+            <text class="seq-num"   x="130" y="322">4</text>
+            <text class="seq-label" x="148" y="322">GET repos — Bearer token (needs gitea:read)</text>
+            <line class="seq-msg"      x1="120" y1="330" x2="905" y2="330" marker-end="url(#arrow)" />
+            <text class="seq-label" x="897" y="358" text-anchor="end">repo list</text>
+            <line class="seq-msg ret"  x1="905" y1="366" x2="120" y2="366" marker-end="url(#arrow)" />
+          </g>
 
-    <div id="steps"></div>
+          <g data-step="gitea-create" class="g">
+            <text class="seq-num"   x="130" y="402">5</text>
+            <text class="seq-label" x="148" y="402">POST repo — Bearer token (needs gitea:write)</text>
+            <line class="seq-msg"      x1="120" y1="410" x2="905" y2="410" marker-end="url(#arrow)" />
+            <text class="seq-label" x="897" y="438" text-anchor="end">created — or 403 denied if read-only</text>
+            <line class="seq-msg ret"  x1="905" y1="446" x2="120" y2="446" marker-end="url(#arrow)" />
+          </g>
+        </svg>
+      </div>
+
+      <div id="steps"></div>
+    </section>
+
+    <!-- ============================ HOW IT WORKS ============================ -->
+    <section id="tab-how" class="prose" hidden>
+      <h2>What is Cross-App Access (ID-JAG)?</h2>
+      <p><b>Cross-App Access (XAA)</b> lets one application (the <b>Requesting
+      App</b>) obtain access to another (the <b>Receiving App</b>) <i>on behalf
+      of a signed-in user</i> — without the Receiving App ever seeing the user's
+      password, and without the user re-consenting for every app pair.</p>
+      <p>It is built on two OAuth 2.0 building blocks:</p>
+      <ul>
+        <li><b>ID-JAG</b> (Identity Assertion JWT Authorization Grant) — a
+        central IdP mints a short-lived, signed <b>assertion</b> that says
+        "this user authorizes this app to act". <code>draft-ietf-oauth-identity-assertion-authz-grant</code>.</li>
+        <li><b>Token exchange</b> (<code>RFC 8693</code>) — a service swaps one
+        token for another, optionally <b>downscoping</b> it to just what the next
+        call needs.</li>
+      </ul>
+      <div class="note"><b>Keycloak's role today:</b> Keycloak 26.7 implements
+      the ID-JAG <b>Receiver</b> only — it accepts an externally-signed assertion
+      at its token endpoint and issues a local access token. It cannot yet
+      <b>mint</b> assertions, so this demo uses a small <code>idjag-issuer</code>
+      service as the stand-in enterprise IdP.</div>
+
+      <h2>How Keycloak is configured</h2>
+
+      <h3>1. Experimental feature flags</h3>
+      <p>Keycloak is started with the flags from the
+      <a href="https://www.keycloak.org/securing-apps/identity-assertion-jwt-authorization-grant">ID-JAG guide</a>:</p>
+      <pre><code>start-dev --import-realm \
+  --features=identity-assertion-jwt,token-exchange-delegation,parameterized-scopes</code></pre>
+      <ul>
+        <li><code>identity-assertion-jwt</code> — enables the ID-JAG receiver (the <code>jwt-bearer</code> grant). Needs Keycloak 26.7+.</li>
+        <li><code>token-exchange-delegation</code> — enables the delegation scope for RFC 8693 token exchange.</li>
+        <li><code>parameterized-scopes</code> — dependency of the delegation feature.</li>
+      </ul>
+
+      <h3>2. The Receiving App client (the ID-JAG receiver)</h3>
+      <p>In <code>keycloak/cncf-demo-realm.json</code>, <code>receiving-app</code>
+      is a confidential client with the ID-JAG grant enabled:</p>
+      <pre><code>{
+  "clientId": "receiving-app",
+  "serviceAccountsEnabled": true,
+  "attributes": {
+    "oauth2.jwt.authorization.grant.enabled": "true",
+    "oauth2.jwt.authorization.grant.idp": "id-jag"
+  }
+}</code></pre>
+      <p>The <code>...grant.idp</code> attribute points at the identity provider
+      Keycloak trusts to have signed incoming assertions.</p>
+
+      <h3>3. The <code>id-jag</code> identity provider (the trust anchor)</h3>
+      <p>An OIDC identity provider named <code>id-jag</code> tells Keycloak where
+      to fetch the issuer's public keys (JWKS) so it can verify assertion
+      signatures, and <code>jwtAuthorizationGrantEnabled=true</code> allows it to
+      be used for the grant. In this demo it points at <code>idjag-issuer</code>;
+      swap the issuer/JWKS URLs for your real enterprise IdP.</p>
+
+      <h3>4. Narrow scopes (registered by <code>kc-init</code>)</h3>
+      <p>The <code>gitea:read</code> / <code>gitea:write</code> client scopes are
+      registered with <code>kcadm</code> after the realm import and assigned as
+      <b>optional</b> scopes on <code>receiving-app</code> — so they are only
+      granted when explicitly requested:</p>
+      <pre><code>kcadm.sh create client-scopes -r cncf-demo \
+  -s name=gitea:read -s protocol=openid-connect \
+  -s 'attributes."include.in.token.scope"=true'
+# then assign as an OPTIONAL scope on receiving-app</code></pre>
+      <div class="note">Hand-authoring <code>clientScopes</code> in a realm
+      import <b>replaces</b> Keycloak's built-in scopes (profile, email, …), so
+      the demo registers the gitea scopes via <code>kcadm</code> after import
+      instead — keeping the standard scopes intact.</div>
+
+      <h3>5. The exchange call</h3>
+      <p>The Receiving App presents the assertion to Keycloak's token endpoint.
+      Keycloak verifies the signature (against the issuer JWKS), the audience and
+      client, maps <code>sub</code> to the local user via the federated identity
+      link, and returns a <b>downscoped</b> access token:</p>
+      <pre><code>POST /realms/cncf-demo/protocol/openid-connect/token
+  grant_type = urn:ietf:params:oauth:grant-type:jwt-bearer
+  assertion  = &lt;signed ID-JAG JWT&gt;
+  client_id  = receiving-app
+  scope      = openid gitea:read        # request only what you need</code></pre>
+
+      <h2>More sequences</h2>
+
+      <h3>A. One-time trust setup <span class="tag today">today</span></h3>
+      <div class="diagram doc">
+        <svg viewBox="0 0 1000 300" role="img" aria-label="Trust setup sequence">
+          <g>
+            <rect class="seq-actor-box" x="30"  y="10" width="220" height="30" rx="5" />
+            <text class="seq-actor" x="140" y="30" text-anchor="middle">Realm import / kc-init</text>
+            <rect class="seq-actor-box" x="410" y="10" width="180" height="30" rx="5" />
+            <text class="seq-actor" x="500" y="30" text-anchor="middle">Keycloak</text>
+            <rect class="seq-actor-box" x="760" y="10" width="200" height="30" rx="5" />
+            <text class="seq-actor" x="860" y="30" text-anchor="middle">ID-JAG Issuer</text>
+            <line class="seq-life" x1="140" y1="40" x2="140" y2="290" />
+            <line class="seq-life" x1="500" y1="40" x2="500" y2="290" />
+            <line class="seq-life" x1="860" y1="40" x2="860" y2="290" />
+          </g>
+          <g>
+            <text class="seq-num" x="150" y="82">1</text>
+            <text class="seq-label" x="168" y="82">import realm: receiving-app (jwt-bearer) + id-jag IdP</text>
+            <line class="seq-msg" x1="140" y1="90" x2="500" y2="90" marker-end="url(#arrow)" />
+          </g>
+          <g>
+            <text class="seq-num" x="150" y="142">2</text>
+            <text class="seq-label" x="168" y="142">kc-init: register gitea:read / gitea:write (optional scopes)</text>
+            <line class="seq-msg" x1="140" y1="150" x2="500" y2="150" marker-end="url(#arrow)" />
+          </g>
+          <g>
+            <text class="seq-num" x="510" y="212">3</text>
+            <text class="seq-label" x="528" y="212">at runtime: fetch issuer JWKS to verify assertions</text>
+            <line class="seq-msg" x1="500" y1="220" x2="860" y2="220" marker-end="url(#arrow)" />
+            <text class="seq-label" x="852" y="248" text-anchor="end">JWKS (public keys)</text>
+            <line class="seq-msg ret" x1="860" y1="256" x2="500" y2="256" marker-end="url(#arrow)" />
+          </g>
+        </svg>
+      </div>
+      <p class="caption">Keycloak learns to trust the issuer's signatures via the
+      <code>id-jag</code> IdP's JWKS URL; <code>kc-init</code> adds the narrow
+      scopes.</p>
+
+      <h3>B. The exchange &amp; narrow-scoping enforcement <span class="tag live">live</span></h3>
+      <div class="diagram doc">
+        <svg viewBox="0 0 1000 380" role="img" aria-label="Exchange and enforcement sequence">
+          <g>
+            <rect class="seq-actor-box" x="30"  y="10" width="200" height="30" rx="5" />
+            <text class="seq-actor" x="130" y="30" text-anchor="middle">Receiving App</text>
+            <rect class="seq-actor-box" x="400" y="10" width="200" height="30" rx="5" />
+            <text class="seq-actor" x="500" y="30" text-anchor="middle">Keycloak</text>
+            <rect class="seq-actor-box" x="770" y="10" width="200" height="30" rx="5" />
+            <text class="seq-actor" x="870" y="30" text-anchor="middle">Gitea gateway</text>
+            <line class="seq-life" x1="130" y1="40" x2="130" y2="370" />
+            <line class="seq-life" x1="500" y1="40" x2="500" y2="370" />
+            <line class="seq-life" x1="870" y1="40" x2="870" y2="370" />
+          </g>
+          <g>
+            <text class="seq-num" x="140" y="82">1</text>
+            <text class="seq-label" x="158" y="82">jwt-bearer + scope=gitea:read</text>
+            <line class="seq-msg" x1="130" y1="90" x2="500" y2="90" marker-end="url(#arrow)" />
+            <text class="seq-note" x="500" y="118" text-anchor="middle">verify sig (JWKS), aud, client; map sub; grant requested optional scopes only</text>
+            <text class="seq-label" x="492" y="146" text-anchor="end">access token (scope: gitea:read)</text>
+            <line class="seq-msg ret" x1="500" y1="154" x2="130" y2="154" marker-end="url(#arrow)" />
+          </g>
+          <g>
+            <text class="seq-num" x="140" y="212">2</text>
+            <text class="seq-label" x="158" y="212">GET /repos + Bearer</text>
+            <line class="seq-msg" x1="130" y1="220" x2="870" y2="220" marker-end="url(#arrow)" />
+            <text class="seq-note" x="870" y="246" text-anchor="middle">verify token; require gitea:read</text>
+            <text class="seq-label" x="862" y="272" text-anchor="end">200 — repo list</text>
+            <line class="seq-msg ret" x1="870" y1="280" x2="130" y2="280" marker-end="url(#arrow)" />
+          </g>
+          <g>
+            <text class="seq-num" x="140" y="330">3</text>
+            <text class="seq-label" x="158" y="330">POST /repos + Bearer (no gitea:write)</text>
+            <line class="seq-msg alt" x1="130" y1="338" x2="870" y2="338" marker-end="url(#arrow)" />
+            <text class="seq-label" x="862" y="366" text-anchor="end">403 — insufficient_scope</text>
+            <line class="seq-msg ret" x1="870" y1="358" x2="130" y2="358" marker-end="url(#arrow)" />
+          </g>
+        </svg>
+      </div>
+      <p class="caption">The token is only as powerful as the scope requested;
+      the gateway (an OAuth resource server) refuses out-of-scope operations.</p>
+
+      <h2>Identity node &amp; Verifiable Credentials</h2>
+      <p>The stack also runs the <b>AGNTCY identity node</b> (REST
+      <code>:4003</code>, gRPC <code>:4004</code>). It is a <b>registry and
+      resolver</b> for agent/app identities and their <b>Verifiable Credentials
+      (VCs)</b> — AGNTCY calls these <b>Badges</b> (e.g. <code>AgentBadge</code>,
+      <code>McpBadge</code>), which are W3C VCs carried in a JOSE envelope.</p>
+
+      <table>
+        <tr><th>Node endpoint (<code>/v1alpha1</code>)</th><th>Purpose</th></tr>
+        <tr><td><code>POST /issuer/register</code></td><td>Register a tenant issuer + its public JWK</td></tr>
+        <tr><td><code>POST /id/generate</code></td><td>Mint a resolvable identity (<code>ResolverMetadata</code>) from an OIDC proof</td></tr>
+        <tr><td><code>POST /vc/publish</code></td><td>Store a signed VC (validates the OIDC proof against the subject)</td></tr>
+        <tr><td><code>POST /vc/verify</code></td><td>Cryptographically verify a VC</td></tr>
+        <tr><td><code>GET /vc/{id}/.well-known/vcs.json</code></td><td>Public resolution of an identity's VCs</td></tr>
+      </table>
+      <p class="caption">VC <b>signing</b> happens in the Identity Service BFF
+      (with the tenant key from Vault); the node <b>publishes / resolves /
+      verifies</b>. The CNCF stack currently runs the node but not the BFF.</p>
+
+      <h3>C. Issuing a VC (Badge) with the identity node <span class="tag today">today</span></h3>
+      <div class="diagram doc">
+        <svg viewBox="0 0 1000 420" role="img" aria-label="VC issuance sequence">
+          <g>
+            <rect class="seq-actor-box" x="30"  y="10" width="220" height="30" rx="5" />
+            <text class="seq-actor" x="140" y="30" text-anchor="middle">Issuer / BFF</text>
+            <rect class="seq-actor-box" x="410" y="10" width="180" height="30" rx="5" />
+            <text class="seq-actor" x="500" y="30" text-anchor="middle">Keycloak</text>
+            <rect class="seq-actor-box" x="760" y="10" width="210" height="30" rx="5" />
+            <text class="seq-actor" x="865" y="30" text-anchor="middle">Identity Node</text>
+            <line class="seq-life" x1="140" y1="40" x2="140" y2="410" />
+            <line class="seq-life" x1="500" y1="40" x2="500" y2="410" />
+            <line class="seq-life" x1="865" y1="40" x2="865" y2="410" />
+          </g>
+          <g>
+            <text class="seq-num" x="150" y="82">1</text>
+            <text class="seq-label" x="168" y="82">client_credentials &rarr; OIDC proof JWT</text>
+            <line class="seq-msg" x1="140" y1="90" x2="500" y2="90" marker-end="url(#arrow)" />
+            <text class="seq-label" x="492" y="118" text-anchor="end">proof token</text>
+            <line class="seq-msg ret" x1="500" y1="126" x2="140" y2="126" marker-end="url(#arrow)" />
+          </g>
+          <g>
+            <text class="seq-num" x="150" y="182">2</text>
+            <text class="seq-label" x="168" y="182">POST /issuer/register (JWK + proof), POST /id/generate</text>
+            <line class="seq-msg" x1="140" y1="190" x2="865" y2="190" marker-end="url(#arrow)" />
+            <text class="seq-label" x="857" y="218" text-anchor="end">resolver_metadata_id</text>
+            <line class="seq-msg ret" x1="865" y1="226" x2="140" y2="226" marker-end="url(#arrow)" />
+          </g>
+          <g>
+            <text class="seq-num" x="150" y="286">3</text>
+            <text class="seq-note" x="150" y="270">sign Badge VC locally with tenant key</text>
+            <text class="seq-label" x="168" y="286">POST /vc/publish (JOSE VC + OIDC proof)</text>
+            <line class="seq-msg" x1="140" y1="294" x2="865" y2="294" marker-end="url(#arrow)" />
+            <text class="seq-label" x="857" y="322" text-anchor="end">stored</text>
+            <line class="seq-msg ret" x1="865" y1="330" x2="140" y2="330" marker-end="url(#arrow)" />
+          </g>
+          <g>
+            <text class="seq-num" x="150" y="386">4</text>
+            <text class="seq-label" x="168" y="386">GET /vc/{id}/.well-known/vcs.json &nbsp;·&nbsp; POST /vc/verify</text>
+            <line class="seq-msg" x1="140" y1="394" x2="865" y2="394" marker-end="url(#arrow)" />
+          </g>
+        </svg>
+      </div>
+      <p class="caption">A Badge binds an app/agent's <code>resolver_metadata_id</code>
+      to signed metadata (agent card / MCP definition), publicly resolvable via
+      well-known.</p>
+
+      <h3>D. VC-backed ID-JAG — how VCs plug into this flow <span class="tag proposed">proposed</span></h3>
+      <div class="diagram doc">
+        <svg viewBox="0 0 1000 400" role="img" aria-label="VC-backed ID-JAG sequence">
+          <g>
+            <rect class="seq-actor-box" x="10"  y="10" width="170" height="30" rx="5" />
+            <text class="seq-actor" x="95" y="30" text-anchor="middle">Requesting App</text>
+            <rect class="seq-actor-box" x="215" y="10" width="150" height="30" rx="5" />
+            <text class="seq-actor" x="290" y="30" text-anchor="middle">ID-JAG Issuer</text>
+            <rect class="seq-actor-box" x="415" y="10" width="150" height="30" rx="5" />
+            <text class="seq-actor" x="490" y="30" text-anchor="middle">Keycloak</text>
+            <rect class="seq-actor-box" x="620" y="10" width="150" height="30" rx="5" />
+            <text class="seq-actor" x="695" y="30" text-anchor="middle">Gitea gateway</text>
+            <rect class="seq-actor-box" x="820" y="10" width="160" height="30" rx="5" />
+            <text class="seq-actor" x="900" y="30" text-anchor="middle">Identity Node</text>
+            <line class="seq-life" x1="95"  y1="40" x2="95"  y2="390" />
+            <line class="seq-life" x1="290" y1="40" x2="290" y2="390" />
+            <line class="seq-life" x1="490" y1="40" x2="490" y2="390" />
+            <line class="seq-life" x1="695" y1="40" x2="695" y2="390" />
+            <line class="seq-life" x1="900" y1="40" x2="900" y2="390" />
+          </g>
+          <g>
+            <text class="seq-num" x="105" y="82">1</text>
+            <text class="seq-label" x="123" y="82">mint ID-JAG incl. agent VC ref (resolver_metadata_id / vc+jwt)</text>
+            <line class="seq-msg alt" x1="95" y1="90" x2="290" y2="90" marker-end="url(#arrow)" />
+            <text class="seq-label" x="282" y="118" text-anchor="end">assertion (+ VC claim)</text>
+            <line class="seq-msg ret" x1="290" y1="126" x2="95" y2="126" marker-end="url(#arrow)" />
+          </g>
+          <g>
+            <text class="seq-num" x="105" y="182">2</text>
+            <text class="seq-label" x="123" y="182">jwt-bearer exchange</text>
+            <line class="seq-msg" x1="95" y1="190" x2="490" y2="190" marker-end="url(#arrow)" />
+            <text class="seq-label" x="482" y="218" text-anchor="end">scoped access token</text>
+            <line class="seq-msg ret" x1="490" y1="226" x2="95" y2="226" marker-end="url(#arrow)" />
+          </g>
+          <g>
+            <text class="seq-num" x="105" y="282">3</text>
+            <text class="seq-label" x="123" y="282">call API + Bearer</text>
+            <line class="seq-msg" x1="95" y1="290" x2="695" y2="290" marker-end="url(#arrow)" />
+          </g>
+          <g>
+            <text class="seq-num" x="705" y="332">4</text>
+            <text class="seq-label" x="723" y="332">verify agent VC (/vc/verify, resolve)</text>
+            <line class="seq-msg alt" x1="695" y1="340" x2="900" y2="340" marker-end="url(#arrow)" />
+            <text class="seq-label" x="892" y="368" text-anchor="end">VC valid + subject match</text>
+            <line class="seq-msg ret" x1="900" y1="376" x2="695" y2="376" marker-end="url(#arrow)" />
+          </g>
+        </svg>
+      </div>
+      <p class="caption">The gateway (or Keycloak, via the DCR
+      <code>vc+jwt</code> / Client-ID-Metadata proposal) verifies the agent's VC
+      through the identity node before honoring the token — adding
+      <b>cryptographic proof of the calling agent's identity</b> on top of the
+      user-delegated access.</p>
+
+      <div class="note"><b>Why this matters:</b> ID-JAG proves <i>the user
+      authorized this app</i>. The VC proves <i>this app/agent is who it claims
+      to be</i> (issued and signed by a trusted issuer, resolvable and
+      revocable). Together you get delegated access <b>plus</b> verifiable agent
+      identity — least privilege with provenance.</div>
+
+      <div class="note"><b>Wiring it live (next step):</b> issuing a VC needs a
+      signer. Two options: (1) run the Identity Service BFF, which signs Badges
+      with the tenant key and publishes them to the node; or (2) have
+      <code>idjag-issuer</code> double as a VC issuer — it already holds an RSA
+      key + JWKS, so it can register with the node, sign a Badge for
+      <code>requesting-app</code>, publish it, and add the
+      <code>resolver_metadata_id</code> as a claim in the ID-JAG assertion, with
+      the gateway calling <code>/vc/verify</code> before allowing the Gitea call.</div>
+    </section>
   </main>
 
   <script>
+    // ---- tab switching -------------------------------------------------
+    const tabs = document.querySelectorAll('.tab');
+    tabs.forEach(t => t.addEventListener('click', () => {
+      tabs.forEach(x => x.classList.toggle('active', x === t));
+      document.getElementById('tab-demo').hidden = t.dataset.tab !== 'demo';
+      document.getElementById('tab-how').hidden = t.dataset.tab !== 'how';
+    }));
+
+    // ---- live demo -----------------------------------------------------
     const stepsEl = document.getElementById('steps');
     const runBtn = document.getElementById('run');
     const stepBtn = document.getElementById('step');

--- a/demos/cncf-stack/webapp/static/index.html
+++ b/demos/cncf-stack/webapp/static/index.html
@@ -55,14 +55,14 @@
 <body>
   <header>
     <div>
-      <h1>CNCF Demo &mdash; ID-JAG (Cross-App Access)</h1>
-      <div class="sub">External issuer &rarr; Keycloak 26.7 receiver (<code>jwt-bearer</code>) &rarr; local access token</div>
+      <h1>Cross-App Access &mdash; Requesting App &rarr; Receiving App</h1>
+      <div class="sub">ID-JAG issuer &rarr; Keycloak 26.7 receiver (<code>jwt-bearer</code>) &rarr; local access token</div>
     </div>
     <button id="run">Run ID-JAG sequence</button>
   </header>
   <main>
     <div class="config" id="config"></div>
-    <div class="flow">Three server-side hops. Each card shows the decoded JWT header + claims.</div>
+    <div class="flow">The Requesting App gets access to the Receiving App on the user's behalf. Three server-side hops &mdash; each card shows the decoded JWT header + claims.</div>
     <div id="steps"></div>
   </main>
 
@@ -71,9 +71,9 @@
     const runBtn = document.getElementById('run');
 
     const TEMPLATE = [
-      { id: 'login',    title: '1. User login (OIDC password grant)' },
-      { id: 'mint',     title: '2. Mint ID-JAG assertion (external issuer)' },
-      { id: 'exchange', title: '3. Receiver exchange (Keycloak jwt-bearer)' },
+      { id: 'login',    title: '1. Requesting App — user sign-in (OIDC password grant)' },
+      { id: 'mint',     title: '2. Mint ID-JAG assertion (for the Receiving App)' },
+      { id: 'exchange', title: '3. Receiving App — exchange (Keycloak jwt-bearer)' },
     ];
 
     function render(steps) {
@@ -105,8 +105,8 @@
         document.getElementById('config').innerHTML =
           `<div><b>Keycloak:</b> ${escapeHtml(c.keycloak)}</div>
            <div><b>Realm:</b> ${escapeHtml(c.realm)}</div>
-           <div><b>User client:</b> ${escapeHtml(c.user_client)}</div>
-           <div><b>Backend client:</b> ${escapeHtml(c.backend_client)}</div>
+           <div><b>Requesting App:</b> ${escapeHtml(c.user_client)}</div>
+           <div><b>Receiving App:</b> ${escapeHtml(c.backend_client)}</div>
            <div><b>Demo user:</b> ${escapeHtml(c.demo_user)}</div>
            <div><b>ID-JAG issuer:</b> ${escapeHtml(c.issuer)}</div>`;
       } catch (e) { /* ignore */ }

--- a/demos/cncf-stack/webapp/static/index.html
+++ b/demos/cncf-stack/webapp/static/index.html
@@ -8,7 +8,7 @@
     :root {
       --bg: #0d1117; --panel: #161b22; --border: #30363d;
       --text: #e6edf3; --muted: #8b949e; --accent: #2f81f7;
-      --ok: #3fb950; --err: #f85149; --run: #d29922;
+      --ok: #3fb950; --err: #f85149; --run: #d29922; --denied: #db8f2f;
     }
     * { box-sizing: border-box; }
     body {
@@ -48,6 +48,11 @@
     .badge.running { background: rgba(210,153,34,.15); color: var(--run); }
     .badge.ok { background: rgba(63,185,80,.15); color: var(--ok); }
     .badge.error { background: rgba(248,81,73,.15); color: var(--err); }
+    .badge.denied { background: rgba(219,143,47,.18); color: var(--denied); }
+    .scope-pick { display: flex; align-items: center; gap: 10px; font-size: 13px; color: var(--muted);
+      background: var(--panel); border: 1px solid var(--border); border-radius: 8px; padding: 8px 14px; margin-bottom: 16px; flex-wrap: wrap; }
+    .scope-pick label { display: inline-flex; align-items: center; gap: 6px; color: var(--text); cursor: pointer; }
+    .scope-pick code { color: var(--accent); }
     pre {
       margin: 0; padding: 14px 16px; background: #0b0f14; border-top: 1px solid var(--border);
       font-size: 12px; overflow-x: auto; color: #c9d1d9; max-height: 320px;
@@ -70,13 +75,14 @@
     .g.running .seq-msg { stroke: var(--run); } .g.running .seq-label, .g.running .seq-num { fill: var(--run); }
     .g.ok .seq-msg { stroke: var(--ok); } .g.ok .seq-label, .g.ok .seq-num { fill: var(--ok); }
     .g.error .seq-msg { stroke: var(--err); } .g.error .seq-label, .g.error .seq-num { fill: var(--err); }
+    .g.denied .seq-msg { stroke: var(--denied); } .g.denied .seq-label, .g.denied .seq-num { fill: var(--denied); }
   </style>
 </head>
 <body>
   <header>
     <div>
-      <h1>Cross-App Access &mdash; Requesting App &rarr; Receiving App</h1>
-      <div class="sub">ID-JAG issuer &rarr; Keycloak 26.7 receiver (<code>jwt-bearer</code>) &rarr; local access token</div>
+      <h1>Cross-App Access &mdash; Requesting App &rarr; Receiving App &rarr; Gitea</h1>
+      <div class="sub">ID-JAG issuer &rarr; Keycloak 26.7 receiver (<code>jwt-bearer</code>) &rarr; scoped access token &rarr; Gitea via gateway</div>
     </div>
     <div class="controls">
       <button id="run">Run (animated)</button>
@@ -86,10 +92,17 @@
   </header>
   <main>
     <div class="config" id="config"></div>
-    <div class="flow">The Requesting App gets access to the Receiving App on the user's behalf. <b>Run (animated)</b> plays all three hops with a pause between each; <b>Next step</b> lets you execute them one at a time. Each card shows the decoded JWT header + claims.</div>
+
+    <div class="scope-pick">
+      <span><b>Requested scope:</b></span>
+      <label><input type="radio" name="scope" value="openid gitea:read" checked> Read-only <code>gitea:read</code></label>
+      <label><input type="radio" name="scope" value="openid gitea:read gitea:write"> Read + write <code>gitea:read gitea:write</code></label>
+    </div>
+
+    <div class="flow">The Requesting App gets access to the Receiving App on the user's behalf, then the Receiving App calls Gitea with the exchanged token. The gateway enforces the requested scope: with <b>read-only</b>, listing repos succeeds but creating one is <b>denied (403)</b> — narrow scoping in action. <b>Run (animated)</b> plays all hops with a pause between each; <b>Next step</b> runs them one at a time.</div>
 
     <div class="diagram">
-      <svg viewBox="0 0 860 340" role="img" aria-label="ID-JAG cross-app access sequence diagram">
+      <svg viewBox="0 0 1000 480" role="img" aria-label="ID-JAG cross-app access with Gitea narrow scoping sequence diagram">
         <defs>
           <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
             <path d="M0,0 L10,5 L0,10 z" fill="context-stroke" />
@@ -98,43 +111,64 @@
 
         <!-- actors -->
         <g>
-          <rect class="seq-actor-box" x="60"  y="10" width="160" height="30" rx="5" />
-          <text class="seq-actor" x="140" y="30" text-anchor="middle">Requesting App</text>
-          <rect class="seq-actor-box" x="350" y="10" width="160" height="30" rx="5" />
-          <text class="seq-actor" x="430" y="30" text-anchor="middle">ID-JAG Issuer</text>
-          <rect class="seq-actor-box" x="640" y="10" width="180" height="30" rx="5" />
-          <text class="seq-actor" x="730" y="30" text-anchor="middle">Keycloak / Receiving App</text>
+          <rect class="seq-actor-box" x="45"  y="10" width="150" height="30" rx="5" />
+          <text class="seq-actor" x="120" y="30" text-anchor="middle">Requesting App</text>
+          <rect class="seq-actor-box" x="305" y="10" width="150" height="30" rx="5" />
+          <text class="seq-actor" x="380" y="30" text-anchor="middle">ID-JAG Issuer</text>
+          <rect class="seq-actor-box" x="560" y="10" width="170" height="30" rx="5" />
+          <text class="seq-actor" x="645" y="30" text-anchor="middle">Keycloak / Receiving</text>
+          <rect class="seq-actor-box" x="830" y="10" width="150" height="30" rx="5" />
+          <text class="seq-actor" x="905" y="30" text-anchor="middle">Gitea (gateway)</text>
           <!-- lifelines -->
-          <line class="seq-life" x1="140" y1="40" x2="140" y2="330" />
-          <line class="seq-life" x1="430" y1="40" x2="430" y2="330" />
-          <line class="seq-life" x1="730" y1="40" x2="730" y2="330" />
+          <line class="seq-life" x1="120" y1="40" x2="120" y2="470" />
+          <line class="seq-life" x1="380" y1="40" x2="380" y2="470" />
+          <line class="seq-life" x1="645" y1="40" x2="645" y2="470" />
+          <line class="seq-life" x1="905" y1="40" x2="905" y2="470" />
         </g>
 
         <!-- 1. sign in -->
         <g data-step="login" class="g">
-          <text class="seq-num"   x="150" y="82">1</text>
-          <text class="seq-label" x="168" y="82">User sign-in — password grant</text>
-          <line class="seq-msg"      x1="140" y1="90"  x2="730" y2="90"  marker-end="url(#arrow)" />
-          <text class="seq-label" x="722" y="118" text-anchor="end">user access token</text>
-          <line class="seq-msg ret"  x1="730" y1="126" x2="140" y2="126" marker-end="url(#arrow)" />
+          <text class="seq-num"   x="130" y="82">1</text>
+          <text class="seq-label" x="148" y="82">User sign-in — password grant</text>
+          <line class="seq-msg"      x1="120" y1="90"  x2="645" y2="90"  marker-end="url(#arrow)" />
+          <text class="seq-label" x="637" y="118" text-anchor="end">user access token</text>
+          <line class="seq-msg ret"  x1="645" y1="126" x2="120" y2="126" marker-end="url(#arrow)" />
         </g>
 
         <!-- 2. mint -->
         <g data-step="mint" class="g">
-          <text class="seq-num"   x="150" y="162">2</text>
-          <text class="seq-label" x="168" y="162">Mint ID-JAG (sub = user, act = Requesting App)</text>
-          <line class="seq-msg"      x1="140" y1="170" x2="430" y2="170" marker-end="url(#arrow)" />
-          <text class="seq-label" x="422" y="198" text-anchor="end">signed assertion</text>
-          <line class="seq-msg ret"  x1="430" y1="206" x2="140" y2="206" marker-end="url(#arrow)" />
+          <text class="seq-num"   x="130" y="162">2</text>
+          <text class="seq-label" x="148" y="162">Mint ID-JAG (sub = user, act = Requesting App, scope)</text>
+          <line class="seq-msg"      x1="120" y1="170" x2="380" y2="170" marker-end="url(#arrow)" />
+          <text class="seq-label" x="372" y="198" text-anchor="end">signed assertion</text>
+          <line class="seq-msg ret"  x1="380" y1="206" x2="120" y2="206" marker-end="url(#arrow)" />
         </g>
 
         <!-- 3. exchange -->
         <g data-step="exchange" class="g">
-          <text class="seq-num"   x="150" y="242">3</text>
-          <text class="seq-label" x="168" y="242">jwt-bearer exchange (assertion)</text>
-          <line class="seq-msg"      x1="140" y1="250" x2="730" y2="250" marker-end="url(#arrow)" />
-          <text class="seq-label" x="722" y="278" text-anchor="end">Receiving App access token</text>
-          <line class="seq-msg ret"  x1="730" y1="286" x2="140" y2="286" marker-end="url(#arrow)" />
+          <text class="seq-num"   x="130" y="242">3</text>
+          <text class="seq-label" x="148" y="242">jwt-bearer exchange (assertion + requested scope)</text>
+          <line class="seq-msg"      x1="120" y1="250" x2="645" y2="250" marker-end="url(#arrow)" />
+          <text class="seq-label" x="637" y="278" text-anchor="end">downscoped access token</text>
+          <line class="seq-msg ret"  x1="645" y1="286" x2="120" y2="286" marker-end="url(#arrow)" />
+        </g>
+
+        <!-- 4. gitea read -->
+        <g data-step="gitea-list" class="g">
+          <text class="seq-num"   x="130" y="322">4</text>
+          <text class="seq-label" x="148" y="322">GET repos — Bearer token (needs gitea:read)</text>
+          <line class="seq-msg"      x1="120" y1="330" x2="905" y2="330" marker-end="url(#arrow)" />
+          <text class="seq-label" x="897" y="358" text-anchor="end">repo list</text>
+          <line class="seq-msg ret"  x1="905" y1="366" x2="120" y2="366" marker-end="url(#arrow)" />
+        </g>
+
+        <!-- 5. gitea write -->
+        <g data-step="gitea-create" class="g">
+          <text class="seq-num"   x="130" y="402">5</text>
+          <text class="seq-label" x="148" y="402">POST repo — Bearer token (needs gitea:write)</text>
+          <line class="seq-msg"      x1="120" y1="410" x2="905" y2="410" marker-end="url(#arrow)" />
+          <text class="seq-label" x="897" y="438" text-anchor="end">created — or 403 denied if read-only</text>
+          <line class="seq-msg ret"  x1="905" y1="446" x2="120" y2="446" marker-end="url(#arrow)" />
         </g>
       </svg>
     </div>
@@ -151,15 +185,18 @@
     // Delay (ms) between hops in animated mode — enough to follow along.
     const STEP_DELAY = 900;
 
-    const ORDER = ['login', 'mint', 'exchange'];
+    const ORDER = ['login', 'mint', 'exchange', 'gitea-list', 'gitea-create'];
     const TITLES = {
-      login:    '1. Requesting App — user sign-in (OIDC password grant)',
-      mint:     '2. Mint ID-JAG assertion (for the Receiving App)',
-      exchange: '3. Receiving App — exchange (Keycloak jwt-bearer)',
+      login:         '1. Requesting App — user sign-in (OIDC password grant)',
+      mint:          '2. Mint ID-JAG assertion (for the Receiving App)',
+      exchange:      '3. Receiving App — exchange (Keycloak jwt-bearer)',
+      'gitea-list':  '4. Receiving App reads Gitea (needs gitea:read)',
+      'gitea-create':'5. Receiving App writes to Gitea (needs gitea:write)',
     };
 
-    let shown = {};          // id -> step object (status/decoded/error/...)
+    let shown = {};          // id -> step object (status/decoded/error/result/...)
     let assertion = null;    // carried from the mint hop into the exchange hop
+    let accessToken = null;  // carried from the exchange hop into the gitea hops
     let cursor = 0;          // index of the next hop to run
     let busy = false;
     const animated = new Set();
@@ -168,6 +205,11 @@
 
     function escapeHtml(s) {
       return String(s).replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
+    }
+
+    function selectedScope() {
+      const el = document.querySelector('input[name="scope"]:checked');
+      return el ? el.value : 'openid gitea:read';
     }
 
     function initShown() {
@@ -184,6 +226,7 @@
         let body = '';
         if (status === 'error') body = `<div class="err-msg">${escapeHtml(s.error || 'error')}</div>`;
         else if (s.decoded) body = `<pre>${escapeHtml(JSON.stringify(s.decoded, null, 2))}</pre>`;
+        else if (s.result) body = `<pre>${escapeHtml(JSON.stringify(s.result, null, 2))}</pre>`;
         const reveal = (status !== 'pending' && !animated.has(id)) ? ' reveal' : '';
         return `<div class="step${reveal}">
           <div class="step-head">
@@ -213,12 +256,15 @@
 
     async function callStep(id) {
       const opts = { method: 'POST', headers: { 'Content-Type': 'application/json' } };
-      if (id === 'exchange') opts.body = JSON.stringify({ assertion: assertion || '' });
+      const scope = selectedScope();
+      if (id === 'mint') opts.body = JSON.stringify({ scope });
+      else if (id === 'exchange') opts.body = JSON.stringify({ assertion: assertion || '', scope });
+      else if (id === 'gitea-list' || id === 'gitea-create') opts.body = JSON.stringify({ access_token: accessToken || '' });
       const res = await fetch('/api/step/' + id, opts);
       return res.json();
     }
 
-    // Execute one hop live and update its card. Returns true on success.
+    // Execute one hop live and update its card. Returns true to continue.
     async function runHop(index) {
       const id = ORDER[index];
       shown[id] = { id, title: TITLES[id], status: 'running' };
@@ -227,6 +273,7 @@
         const data = await callStep(id);
         shown[id] = data.step;
         if (id === 'mint' && data.ok) assertion = data.step.token;
+        if (id === 'exchange' && data.ok) accessToken = data.step.token;
         render();
         return data.ok;
       } catch (e) {
@@ -240,6 +287,7 @@
       if (busy) return;
       initShown();
       assertion = null;
+      accessToken = null;
       cursor = 0;
       render();
       updateButtons();
@@ -282,7 +330,8 @@
            <div><b>Receiving App:</b> ${escapeHtml(c.backend_client)}</div>
            <div><b>Demo user:</b> ${escapeHtml(c.demo_user)}</div>
            <div><b>Subject:</b> ${escapeHtml(c.subject)}</div>
-           <div><b>ID-JAG issuer:</b> ${escapeHtml(c.issuer)}</div>`;
+           <div><b>ID-JAG issuer:</b> ${escapeHtml(c.issuer)}</div>
+           <div><b>Gitea gateway:</b> ${escapeHtml(c.gateway)}</div>`;
       } catch (e) { /* ignore */ }
     }
 

--- a/demos/cncf-stack/webapp/static/index.html
+++ b/demos/cncf-stack/webapp/static/index.html
@@ -26,15 +26,19 @@
       border: 1px solid var(--border); border-radius: 8px; padding: 12px 16px; margin-bottom: 20px;
       display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 4px 20px; }
     .config b { color: var(--text); font-weight: 600; }
+    .controls { display: flex; gap: 8px; flex-wrap: wrap; }
     button {
       background: var(--accent); color: white; border: 0; border-radius: 6px;
       padding: 10px 18px; font-size: 14px; font-weight: 600; cursor: pointer;
     }
+    button.secondary { background: #21262d; color: var(--text); border: 1px solid var(--border); }
     button:disabled { opacity: 0.55; cursor: default; }
     .step {
       background: var(--panel); border: 1px solid var(--border); border-radius: 8px;
       margin: 14px 0; overflow: hidden;
     }
+    .step.reveal { animation: fade-in .45s ease both; }
+    @keyframes fade-in { from { opacity: 0; transform: translateY(6px); } to { opacity: 1; transform: none; } }
     .step-head { padding: 14px 16px; display: flex; align-items: center; gap: 10px; }
     .step-title { font-weight: 600; flex: 1; }
     .step-detail { color: var(--muted); font-size: 12px; font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
@@ -74,11 +78,15 @@
       <h1>Cross-App Access &mdash; Requesting App &rarr; Receiving App</h1>
       <div class="sub">ID-JAG issuer &rarr; Keycloak 26.7 receiver (<code>jwt-bearer</code>) &rarr; local access token</div>
     </div>
-    <button id="run">Run ID-JAG sequence</button>
+    <div class="controls">
+      <button id="run">Run (animated)</button>
+      <button id="step" class="secondary">Next step &#9654;</button>
+      <button id="reset" class="secondary" disabled>Reset</button>
+    </div>
   </header>
   <main>
     <div class="config" id="config"></div>
-    <div class="flow">The Requesting App gets access to the Receiving App on the user's behalf. Three server-side hops &mdash; each card shows the decoded JWT header + claims.</div>
+    <div class="flow">The Requesting App gets access to the Receiving App on the user's behalf. <b>Run (animated)</b> plays all three hops with a pause between each; <b>Next step</b> lets you execute them one at a time. Each card shows the decoded JWT header + claims.</div>
 
     <div class="diagram">
       <svg viewBox="0 0 860 340" role="img" aria-label="ID-JAG cross-app access sequence diagram">
@@ -137,45 +145,132 @@
   <script>
     const stepsEl = document.getElementById('steps');
     const runBtn = document.getElementById('run');
+    const stepBtn = document.getElementById('step');
+    const resetBtn = document.getElementById('reset');
 
-    const TEMPLATE = [
-      { id: 'login',    title: '1. Requesting App — user sign-in (OIDC password grant)' },
-      { id: 'mint',     title: '2. Mint ID-JAG assertion (for the Receiving App)' },
-      { id: 'exchange', title: '3. Receiving App — exchange (Keycloak jwt-bearer)' },
-    ];
+    // Delay (ms) between hops in animated mode — enough to follow along.
+    const STEP_DELAY = 900;
 
-    function render(steps) {
-      const byId = Object.fromEntries(steps.map(s => [s.id, s]));
-      stepsEl.innerHTML = TEMPLATE.map(t => {
-        const s = byId[t.id] || {};
-        const status = s.status || 'pending';
-        const detail = s.detail ? `<div class="step-detail">${escapeHtml(s.detail)}</div>` : '';
-        let body = '';
-        if (s.status === 'error') body = `<div class="err-msg">${escapeHtml(s.error || 'error')}</div>`;
-        else if (s.decoded) body = `<pre>${escapeHtml(JSON.stringify(s.decoded, null, 2))}</pre>`;
-        return `<div class="step">
-          <div class="step-head">
-            <span class="step-title">${escapeHtml(t.title)}</span>
-            <span class="badge ${status}">${status}</span>
-          </div>
-          ${detail}${body}
-        </div>`;
-      }).join('');
-    }
+    const ORDER = ['login', 'mint', 'exchange'];
+    const TITLES = {
+      login:    '1. Requesting App — user sign-in (OIDC password grant)',
+      mint:     '2. Mint ID-JAG assertion (for the Receiving App)',
+      exchange: '3. Receiving App — exchange (Keycloak jwt-bearer)',
+    };
+
+    let shown = {};          // id -> step object (status/decoded/error/...)
+    let assertion = null;    // carried from the mint hop into the exchange hop
+    let cursor = 0;          // index of the next hop to run
+    let busy = false;
+    const animated = new Set();
+
+    const sleep = ms => new Promise(r => setTimeout(r, ms));
 
     function escapeHtml(s) {
       return String(s).replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
     }
 
-    function updateDiagram(steps) {
-      const byId = Object.fromEntries(steps.map(s => [s.id, s]));
-      TEMPLATE.forEach(t => {
-        const g = document.querySelector(`[data-step="${t.id}"]`);
-        if (g) g.setAttribute('class', 'g ' + ((byId[t.id] && byId[t.id].status) || 'pending'));
+    function initShown() {
+      shown = {};
+      animated.clear();
+      ORDER.forEach(id => { shown[id] = { id, title: TITLES[id], status: 'pending' }; });
+    }
+
+    function render() {
+      stepsEl.innerHTML = ORDER.map(id => {
+        const s = shown[id];
+        const status = s.status || 'pending';
+        const detail = s.detail ? `<div class="step-detail">${escapeHtml(s.detail)}</div>` : '';
+        let body = '';
+        if (status === 'error') body = `<div class="err-msg">${escapeHtml(s.error || 'error')}</div>`;
+        else if (s.decoded) body = `<pre>${escapeHtml(JSON.stringify(s.decoded, null, 2))}</pre>`;
+        const reveal = (status !== 'pending' && !animated.has(id)) ? ' reveal' : '';
+        return `<div class="step${reveal}">
+          <div class="step-head">
+            <span class="step-title">${escapeHtml(s.title || TITLES[id])}</span>
+            <span class="badge ${status}">${status}</span>
+          </div>
+          ${detail}${body}
+        </div>`;
+      }).join('');
+      ORDER.forEach(id => { if (shown[id].status !== 'pending') animated.add(id); });
+      updateDiagram();
+    }
+
+    function updateDiagram() {
+      ORDER.forEach(id => {
+        const g = document.querySelector(`[data-step="${id}"]`);
+        if (g) g.setAttribute('class', 'g ' + (shown[id].status || 'pending'));
       });
     }
 
-    function setStates(steps) { render(steps); updateDiagram(steps); }
+    function updateButtons() {
+      runBtn.disabled = busy;
+      stepBtn.disabled = busy || cursor >= ORDER.length;
+      resetBtn.disabled = busy || cursor === 0;
+      stepBtn.textContent = cursor === 0 ? 'Next step \u25B6' : (cursor < ORDER.length ? `Next: ${cursor + 1} \u25B6` : 'Done');
+    }
+
+    async function callStep(id) {
+      const opts = { method: 'POST', headers: { 'Content-Type': 'application/json' } };
+      if (id === 'exchange') opts.body = JSON.stringify({ assertion: assertion || '' });
+      const res = await fetch('/api/step/' + id, opts);
+      return res.json();
+    }
+
+    // Execute one hop live and update its card. Returns true on success.
+    async function runHop(index) {
+      const id = ORDER[index];
+      shown[id] = { id, title: TITLES[id], status: 'running' };
+      render();
+      try {
+        const data = await callStep(id);
+        shown[id] = data.step;
+        if (id === 'mint' && data.ok) assertion = data.step.token;
+        render();
+        return data.ok;
+      } catch (e) {
+        shown[id] = { id, title: TITLES[id], status: 'error', error: String(e) };
+        render();
+        return false;
+      }
+    }
+
+    function reset() {
+      if (busy) return;
+      initShown();
+      assertion = null;
+      cursor = 0;
+      render();
+      updateButtons();
+    }
+
+    // Animated auto-run: execute each hop with a pause in between.
+    runBtn.addEventListener('click', async () => {
+      if (busy) return;
+      reset();
+      busy = true; updateButtons();
+      for (let i = 0; i < ORDER.length; i++) {
+        const ok = await runHop(i);
+        cursor = i + 1;
+        if (!ok) break;
+        if (i < ORDER.length - 1) await sleep(STEP_DELAY);
+      }
+      busy = false; updateButtons();
+    });
+
+    // Manual step-through: one hop per click.
+    stepBtn.addEventListener('click', async () => {
+      if (busy || cursor >= ORDER.length) return;
+      if (cursor === 0) reset();
+      busy = true; updateButtons();
+      const ok = await runHop(cursor);
+      cursor += 1;
+      if (!ok) cursor = ORDER.length; // stop on failure
+      busy = false; updateButtons();
+    });
+
+    resetBtn.addEventListener('click', reset);
 
     async function loadConfig() {
       try {
@@ -191,22 +286,10 @@
       } catch (e) { /* ignore */ }
     }
 
-    runBtn.addEventListener('click', async () => {
-      runBtn.disabled = true;
-      setStates(TEMPLATE.map(t => ({ id: t.id, status: 'running' })));
-      try {
-        const res = await fetch('/api/run', { method: 'POST' });
-        const data = await res.json();
-        setStates(data.steps);
-      } catch (e) {
-        setStates([{ id: 'login', status: 'error', error: String(e) }]);
-      } finally {
-        runBtn.disabled = false;
-      }
-    });
-
     loadConfig();
-    setStates(TEMPLATE.map(t => ({ id: t.id, status: 'pending' })));
+    initShown();
+    render();
+    updateButtons();
   </script>
 </body>
 </html>

--- a/demos/cncf-stack/webapp/static/index.html
+++ b/demos/cncf-stack/webapp/static/index.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>CNCF Demo — ID-JAG (Cross-App Access)</title>
+  <style>
+    :root {
+      --bg: #0d1117; --panel: #161b22; --border: #30363d;
+      --text: #e6edf3; --muted: #8b949e; --accent: #2f81f7;
+      --ok: #3fb950; --err: #f85149; --run: #d29922;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      background: var(--bg); color: var(--text); line-height: 1.5;
+    }
+    header {
+      padding: 24px 32px; border-bottom: 1px solid var(--border);
+      display: flex; align-items: center; justify-content: space-between; flex-wrap: wrap; gap: 12px;
+    }
+    header h1 { font-size: 20px; margin: 0; }
+    header .sub { color: var(--muted); font-size: 13px; margin-top: 4px; }
+    main { max-width: 960px; margin: 0 auto; padding: 24px 32px; }
+    .config { font-size: 12px; color: var(--muted); background: var(--panel);
+      border: 1px solid var(--border); border-radius: 8px; padding: 12px 16px; margin-bottom: 20px;
+      display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 4px 20px; }
+    .config b { color: var(--text); font-weight: 600; }
+    button {
+      background: var(--accent); color: white; border: 0; border-radius: 6px;
+      padding: 10px 18px; font-size: 14px; font-weight: 600; cursor: pointer;
+    }
+    button:disabled { opacity: 0.55; cursor: default; }
+    .step {
+      background: var(--panel); border: 1px solid var(--border); border-radius: 8px;
+      margin: 14px 0; overflow: hidden;
+    }
+    .step-head { padding: 14px 16px; display: flex; align-items: center; gap: 10px; }
+    .step-title { font-weight: 600; flex: 1; }
+    .step-detail { color: var(--muted); font-size: 12px; font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      padding: 0 16px 12px; word-break: break-all; }
+    .badge { font-size: 11px; font-weight: 700; text-transform: uppercase; padding: 3px 8px; border-radius: 20px; }
+    .badge.pending { background: #21262d; color: var(--muted); }
+    .badge.running { background: rgba(210,153,34,.15); color: var(--run); }
+    .badge.ok { background: rgba(63,185,80,.15); color: var(--ok); }
+    .badge.error { background: rgba(248,81,73,.15); color: var(--err); }
+    pre {
+      margin: 0; padding: 14px 16px; background: #0b0f14; border-top: 1px solid var(--border);
+      font-size: 12px; overflow-x: auto; color: #c9d1d9; max-height: 320px;
+    }
+    .err-msg { color: var(--err); padding: 0 16px 14px; font-family: ui-monospace, monospace; font-size: 12px; }
+    .flow { color: var(--muted); font-size: 13px; margin-bottom: 8px; }
+  </style>
+</head>
+<body>
+  <header>
+    <div>
+      <h1>CNCF Demo &mdash; ID-JAG (Cross-App Access)</h1>
+      <div class="sub">External issuer &rarr; Keycloak 26.7 receiver (<code>jwt-bearer</code>) &rarr; local access token</div>
+    </div>
+    <button id="run">Run ID-JAG sequence</button>
+  </header>
+  <main>
+    <div class="config" id="config"></div>
+    <div class="flow">Three server-side hops. Each card shows the decoded JWT header + claims.</div>
+    <div id="steps"></div>
+  </main>
+
+  <script>
+    const stepsEl = document.getElementById('steps');
+    const runBtn = document.getElementById('run');
+
+    const TEMPLATE = [
+      { id: 'login',    title: '1. User login (OIDC password grant)' },
+      { id: 'mint',     title: '2. Mint ID-JAG assertion (external issuer)' },
+      { id: 'exchange', title: '3. Receiver exchange (Keycloak jwt-bearer)' },
+    ];
+
+    function render(steps) {
+      const byId = Object.fromEntries(steps.map(s => [s.id, s]));
+      stepsEl.innerHTML = TEMPLATE.map(t => {
+        const s = byId[t.id] || {};
+        const status = s.status || 'pending';
+        const detail = s.detail ? `<div class="step-detail">${escapeHtml(s.detail)}</div>` : '';
+        let body = '';
+        if (s.status === 'error') body = `<div class="err-msg">${escapeHtml(s.error || 'error')}</div>`;
+        else if (s.decoded) body = `<pre>${escapeHtml(JSON.stringify(s.decoded, null, 2))}</pre>`;
+        return `<div class="step">
+          <div class="step-head">
+            <span class="step-title">${escapeHtml(t.title)}</span>
+            <span class="badge ${status}">${status}</span>
+          </div>
+          ${detail}${body}
+        </div>`;
+      }).join('');
+    }
+
+    function escapeHtml(s) {
+      return String(s).replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
+    }
+
+    async function loadConfig() {
+      try {
+        const c = await (await fetch('/api/config')).json();
+        document.getElementById('config').innerHTML =
+          `<div><b>Keycloak:</b> ${escapeHtml(c.keycloak)}</div>
+           <div><b>Realm:</b> ${escapeHtml(c.realm)}</div>
+           <div><b>User client:</b> ${escapeHtml(c.user_client)}</div>
+           <div><b>Backend client:</b> ${escapeHtml(c.backend_client)}</div>
+           <div><b>Demo user:</b> ${escapeHtml(c.demo_user)}</div>
+           <div><b>ID-JAG issuer:</b> ${escapeHtml(c.issuer)}</div>`;
+      } catch (e) { /* ignore */ }
+    }
+
+    runBtn.addEventListener('click', async () => {
+      runBtn.disabled = true;
+      render(TEMPLATE.map(t => ({ id: t.id, status: 'running' })));
+      try {
+        const res = await fetch('/api/run', { method: 'POST' });
+        const data = await res.json();
+        render(data.steps);
+      } catch (e) {
+        render([{ id: 'login', status: 'error', error: String(e) }]);
+      } finally {
+        runBtn.disabled = false;
+      }
+    });
+
+    loadConfig();
+    render(TEMPLATE.map(t => ({ id: t.id, status: 'pending' })));
+  </script>
+</body>
+</html>

--- a/demos/cncf-stack/webapp/tests/conftest.py
+++ b/demos/cncf-stack/webapp/tests/conftest.py
@@ -1,0 +1,5 @@
+import os
+import sys
+
+# Make the webapp package (app.py) importable when running pytest from anywhere.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))

--- a/demos/cncf-stack/webapp/tests/test_app.py
+++ b/demos/cncf-stack/webapp/tests/test_app.py
@@ -115,3 +115,47 @@ def test_run_stops_when_exchange_fails():
     assert data["ok"] is False
     assert [s["id"] for s in data["steps"]] == ["login", "mint", "exchange"]
     assert data["steps"][2]["status"] == "error"
+
+
+# --- stepped endpoints (manual step-through / animated mode) ---------------
+
+
+@respx.mock
+def test_step_login_returns_single_ok_step():
+    respx.post(webapp.TOKEN_ENDPOINT).mock(
+        return_value=httpx.Response(200, json={"access_token": _jwt(sub="uid-1", azp="requesting-app")})
+    )
+    data = client.post("/api/step/login").json()
+    assert data["ok"] is True
+    assert data["step"]["id"] == "login"
+    assert data["step"]["decoded"]["claims"]["azp"] == "requesting-app"
+
+
+@respx.mock
+def test_step_mint_returns_assertion_as_token():
+    assertion = _jwt(sub="user@example.com", azp="receiving-app")
+    respx.post(f"{webapp.ISSUER_URL}/mint").mock(
+        return_value=httpx.Response(200, json={"assertion": assertion, "claims": {}})
+    )
+    data = client.post("/api/step/mint").json()
+    assert data["ok"] is True
+    assert data["step"]["token"] == assertion
+
+
+@respx.mock
+def test_step_exchange_uses_supplied_assertion():
+    exchanged = _jwt(sub="uid-1", azp="receiving-app")
+    route = respx.post(webapp.TOKEN_ENDPOINT).mock(
+        return_value=httpx.Response(200, json={"access_token": exchanged})
+    )
+    data = client.post("/api/step/exchange", json={"assertion": "some.jwt.assertion"}).json()
+    assert data["ok"] is True
+    assert data["step"]["decoded"]["claims"]["azp"] == "receiving-app"
+    # The assertion we passed must be forwarded to Keycloak's token endpoint.
+    sent = route.calls.last.request.content.decode()
+    assert "assertion=some.jwt.assertion" in sent
+
+
+def test_step_exchange_requires_assertion_field():
+    # Missing the required body field -> 422 from FastAPI validation.
+    assert client.post("/api/step/exchange", json={}).status_code == 422

--- a/demos/cncf-stack/webapp/tests/test_app.py
+++ b/demos/cncf-stack/webapp/tests/test_app.py
@@ -50,13 +50,11 @@ def test_decode_valid_and_invalid():
     assert "error" in webapp._decode("not-a-jwt")
 
 
-@respx.mock
-def test_run_happy_path():
-    login = _jwt(sub="uid-123", azp="requesting-app", preferred_username="user")
-    exchanged = _jwt(sub="uid-123", azp="receiving-app", preferred_username="user")
+def _mock_core(login_azp="requesting-app", exchange_azp="receiving-app"):
+    """Mock the login, mint and exchange hops (token endpoint + issuer)."""
+    login = _jwt(sub="uid-123", azp=login_azp, preferred_username="user")
+    exchanged = _jwt(sub="uid-123", azp=exchange_azp, preferred_username="user")
     mint_assertion = _jwt(sub="user@example.com", aud=webapp.REALM_ISSUER, azp="receiving-app")
-
-    # Steps 1 and 3 both POST the token endpoint (password grant, then jwt-bearer).
     respx.post(webapp.TOKEN_ENDPOINT).mock(
         side_effect=[
             httpx.Response(200, json={"access_token": login}),
@@ -67,11 +65,41 @@ def test_run_happy_path():
         return_value=httpx.Response(200, json={"assertion": mint_assertion, "claims": {}})
     )
 
-    data = client.post("/api/run").json()
+
+@respx.mock
+def test_run_happy_path_read_write():
+    _mock_core()
+    respx.get(f"{webapp.GATEWAY_URL}/api/gitea/repos").mock(
+        return_value=httpx.Response(200, json={"repos": [{"full_name": "demo/x"}], "scope": ["gitea:read", "gitea:write"]})
+    )
+    respx.post(f"{webapp.GATEWAY_URL}/api/gitea/repos").mock(
+        return_value=httpx.Response(201, json={"created": {"full_name": "demo/new"}})
+    )
+
+    data = client.post("/api/run", json={"scope": "openid gitea:read gitea:write"}).json()
     assert data["ok"] is True
-    assert [s["id"] for s in data["steps"]] == ["login", "mint", "exchange"]
+    assert [s["id"] for s in data["steps"]] == ["login", "mint", "exchange", "gitea-list", "gitea-create"]
     assert all(s["status"] == "ok" for s in data["steps"])
     assert data["steps"][2]["decoded"]["claims"]["azp"] == "receiving-app"
+
+
+@respx.mock
+def test_run_readonly_denies_write():
+    """Narrow scoping: read-only token lists repos but is denied the create."""
+    _mock_core()
+    respx.get(f"{webapp.GATEWAY_URL}/api/gitea/repos").mock(
+        return_value=httpx.Response(200, json={"repos": [], "scope": ["gitea:read"]})
+    )
+    respx.post(f"{webapp.GATEWAY_URL}/api/gitea/repos").mock(
+        return_value=httpx.Response(403, json={"detail": {"error": "insufficient_scope", "required": "gitea:write"}})
+    )
+
+    data = client.post("/api/run", json={"scope": "openid gitea:read"}).json()
+    # "denied" is an expected outcome, so the run is still considered ok.
+    assert data["ok"] is True
+    statuses = {s["id"]: s["status"] for s in data["steps"]}
+    assert statuses["gitea-list"] == "ok"
+    assert statuses["gitea-create"] == "denied"
 
 
 @respx.mock
@@ -159,3 +187,39 @@ def test_step_exchange_uses_supplied_assertion():
 def test_step_exchange_requires_assertion_field():
     # Missing the required body field -> 422 from FastAPI validation.
     assert client.post("/api/step/exchange", json={}).status_code == 422
+
+
+@respx.mock
+def test_step_gitea_list_forwards_bearer_token():
+    route = respx.get(f"{webapp.GATEWAY_URL}/api/gitea/repos").mock(
+        return_value=httpx.Response(200, json={"repos": [{"full_name": "demo/x"}], "scope": ["gitea:read"]})
+    )
+    data = client.post("/api/step/gitea-list", json={"access_token": "abc.def.ghi"}).json()
+    assert data["ok"] is True
+    assert data["step"]["status"] == "ok"
+    assert route.calls.last.request.headers["authorization"] == "Bearer abc.def.ghi"
+
+
+@respx.mock
+def test_step_gitea_create_denied_maps_to_denied_status():
+    respx.post(f"{webapp.GATEWAY_URL}/api/gitea/repos").mock(
+        return_value=httpx.Response(403, json={"detail": {"required": "gitea:write"}})
+    )
+    data = client.post("/api/step/gitea-create", json={"access_token": "abc.def.ghi"}).json()
+    # 403 is a valid demo outcome -> "denied", and ok stays True.
+    assert data["ok"] is True
+    assert data["step"]["status"] == "denied"
+
+
+@respx.mock
+def test_step_gitea_create_success():
+    respx.post(f"{webapp.GATEWAY_URL}/api/gitea/repos").mock(
+        return_value=httpx.Response(201, json={"created": {"full_name": "demo/new"}})
+    )
+    data = client.post("/api/step/gitea-create", json={"access_token": "t", "repo_name": "my-repo"}).json()
+    assert data["ok"] is True
+    assert data["step"]["status"] == "ok"
+
+
+def test_step_gitea_requires_access_token_field():
+    assert client.post("/api/step/gitea-list", json={}).status_code == 422

--- a/demos/cncf-stack/webapp/tests/test_app.py
+++ b/demos/cncf-stack/webapp/tests/test_app.py
@@ -1,0 +1,117 @@
+"""Unit tests for the CNCF demo web app.
+
+The three-hop /api/run orchestration is exercised with respx, mocking the
+outbound calls to Keycloak (token endpoint) and the ID-JAG issuer, so the
+tests are fast and require no running stack.
+"""
+
+import time
+
+import httpx
+import jwt as pyjwt
+import respx
+from fastapi.testclient import TestClient
+
+import app as webapp
+
+client = TestClient(webapp.app)
+
+
+def _jwt(**claims) -> str:
+    payload = {"iat": int(time.time()), "exp": int(time.time()) + 300, **claims}
+    return pyjwt.encode(payload, "test-secret", algorithm="HS256")
+
+
+def test_health():
+    r = client.get("/api/health")
+    assert r.status_code == 200
+    assert r.json() == {"status": "ok"}
+
+
+def test_config_uses_renamed_defaults():
+    cfg = client.get("/api/config").json()
+    assert cfg["user_client"] == "requesting-app"
+    assert cfg["backend_client"] == "receiving-app"
+    assert cfg["demo_user"] == "user"
+    assert cfg["subject"] == "user@example.com"
+    assert cfg["realm"] == "cncf-demo"
+
+
+def test_index_served():
+    r = client.get("/")
+    assert r.status_code == 200
+    assert "Cross-App Access" in r.text
+
+
+def test_decode_valid_and_invalid():
+    ok = webapp._decode(_jwt(sub="user@example.com"))
+    assert ok["claims"]["sub"] == "user@example.com"
+    assert ok["header"]["alg"] == "HS256"
+    assert "error" in webapp._decode("not-a-jwt")
+
+
+@respx.mock
+def test_run_happy_path():
+    login = _jwt(sub="uid-123", azp="requesting-app", preferred_username="user")
+    exchanged = _jwt(sub="uid-123", azp="receiving-app", preferred_username="user")
+    mint_assertion = _jwt(sub="user@example.com", aud=webapp.REALM_ISSUER, azp="receiving-app")
+
+    # Steps 1 and 3 both POST the token endpoint (password grant, then jwt-bearer).
+    respx.post(webapp.TOKEN_ENDPOINT).mock(
+        side_effect=[
+            httpx.Response(200, json={"access_token": login}),
+            httpx.Response(200, json={"access_token": exchanged}),
+        ]
+    )
+    respx.post(f"{webapp.ISSUER_URL}/mint").mock(
+        return_value=httpx.Response(200, json={"assertion": mint_assertion, "claims": {}})
+    )
+
+    data = client.post("/api/run").json()
+    assert data["ok"] is True
+    assert [s["id"] for s in data["steps"]] == ["login", "mint", "exchange"]
+    assert all(s["status"] == "ok" for s in data["steps"])
+    assert data["steps"][2]["decoded"]["claims"]["azp"] == "receiving-app"
+
+
+@respx.mock
+def test_run_stops_when_login_fails():
+    respx.post(webapp.TOKEN_ENDPOINT).mock(
+        return_value=httpx.Response(401, json={"error": "invalid_grant"})
+    )
+    data = client.post("/api/run").json()
+    assert data["ok"] is False
+    assert len(data["steps"]) == 1
+    assert data["steps"][0]["id"] == "login"
+    assert data["steps"][0]["status"] == "error"
+
+
+@respx.mock
+def test_run_stops_when_mint_fails():
+    respx.post(webapp.TOKEN_ENDPOINT).mock(
+        return_value=httpx.Response(200, json={"access_token": _jwt(sub="uid")})
+    )
+    respx.post(f"{webapp.ISSUER_URL}/mint").mock(return_value=httpx.Response(500, text="boom"))
+
+    data = client.post("/api/run").json()
+    assert data["ok"] is False
+    assert [s["id"] for s in data["steps"]] == ["login", "mint"]
+    assert data["steps"][1]["status"] == "error"
+
+
+@respx.mock
+def test_run_stops_when_exchange_fails():
+    respx.post(webapp.TOKEN_ENDPOINT).mock(
+        side_effect=[
+            httpx.Response(200, json={"access_token": _jwt(sub="uid")}),
+            httpx.Response(400, json={"error": "invalid_grant"}),
+        ]
+    )
+    respx.post(f"{webapp.ISSUER_URL}/mint").mock(
+        return_value=httpx.Response(200, json={"assertion": _jwt(sub="user@example.com"), "claims": {}})
+    )
+
+    data = client.post("/api/run").json()
+    assert data["ok"] is False
+    assert [s["id"] for s in data["steps"]] == ["login", "mint", "exchange"]
+    assert data["steps"][2]["status"] == "error"


### PR DESCRIPTION
## Summary

Quick Demo: https://app.vidcast.io/share/a943d056-fb63-4840-9083-a4fbb72508a3

Adds `demos/cncf-stack/` for the CNCF conference demo (closes #227): a Docker Compose stack that shows **ID-JAG (Cross-App Access)** end to end and demonstrates **narrow scoping** against a real protected resource (Gitea).

All image versions are pinned; all credentials come from env vars (nothing hardcoded in the compose file).

| Service | Image | Ports | Purpose |
| --- | --- | --- | --- |
| `keycloak` | `quay.io/keycloak/keycloak:26.7` | 8080 | OIDC provider + **ID-JAG** receiver |
| `kc-init` | `quay.io/keycloak/keycloak:26.7` | one-shot | Registers `gitea:read` / `gitea:write` client scopes |
| `idjag-issuer` | built from `./idjag-issuer` | internal | Mints ID-JAG assertions (stand-in issuer) |
| `gitea` | `gitea/gitea:1.22` | 3000, 2222 | Self-hosted git hosting (the protected resource) |
| `gitea-init` | `gitea/gitea:1.22` | one-shot | Seeds the Gitea admin + demo repos |
| `gitea-gateway` | built from `./gitea-gateway` | 9100 | Enforces the narrow ID-JAG scope in front of Gitea |
| `identity-postgres` | `postgres:16` | internal | Identity node DB |
| `identity-vault` | `hashicorp/vault:1.17` | internal | Identity node key storage (dev) |
| `identity-node` | `ghcr.io/agntcy/identity/node:0.0.23` | 4003, 4004 | AGNTCY identity node |
| `webapp` | built from `./webapp` | 8000 | ID-JAG Cross-App Access + narrow-scoping demo UI |

The identity node + Postgres + Vault services are adapted from the `agntcyXAA-MultiEnterprise` `feat/xaa-demo-web-ui` branch.

### Cross-App Access (ID-JAG) + Token Exchange

Keycloak is on **26.7** and started with the experimental features from the [ID-JAG guide](https://www.keycloak.org/securing-apps/identity-assertion-jwt-authorization-grant):

```
start-dev --features=identity-assertion-jwt,token-exchange-delegation,parameterized-scopes
```

> Note: Keycloak currently implements only the **Receiver** side of ID-JAG (accepts an externally-signed assertion, issues a local token). It cannot yet **issue** assertions, so `idjag-issuer` stands in for the central enterprise IdP to make the flow self-contained. These features are experimental.

### ID-JAG demo web app

A small server-side web app (<http://localhost:8000>) drives the flow with an animated auto-run **and** a manual step-through, highlighting an inline sequence diagram:

1. **Requesting App** sign-in (OIDC password grant)
2. **Mint ID-JAG** assertion (`sub` = user, `act` = Requesting App, `scope` = requested)
3. **Receiving App** exchange (`jwt-bearer`) → downscoped local access token
4. **Read Gitea** via the gateway (needs `gitea:read`)
5. **Write Gitea** via the gateway (needs `gitea:write`)

### Narrow scoping (the payoff)

A scope selector picks what the assertion requests. Keycloak issues a **downscoped** token, and `gitea-gateway` (a small OAuth resource server: verifies RS256/JWKS, issuer, expiry, then enforces scope) only honors what the token allows:

| Requested scope | List repos (`gitea:read`) | Create repo (`gitea:write`) |
| --- | --- | --- |
| `gitea:read` | ✅ ok | 🚫 **denied (403)** |
| `gitea:read gitea:write` | ✅ ok | ✅ created |

The `gitea:*` scopes are registered by `kc-init` (via `kcadm`, keeping Keycloak's built-in scopes intact) and assigned as **optional** scopes on `receiving-app`, so they're only granted when explicitly requested.

## Test plan

- [x] `docker compose config` passes
- [x] Clean bring-up (`docker compose down -v && up --build`) — all services healthy; `kc-init` and `gitea-init` exit 0
- [x] Keycloak (26.7) starts with `identity-assertion-jwt`, `parameterized-scopes`, `token-exchange-delegation` enabled
- [x] `jwt-bearer` exchange honors the requested narrow scope (verified: read-only excludes `gitea:write`)
- [x] Read-only run lists repos but is **denied** the write; read+write run creates the repo
- [x] Unit tests pass — issuer (10), webapp (17), gitea-gateway (9)
- [x] Playwright E2E (5) — both scope scenarios + step-through
- [ ] Reviewer: confirm intended folder name is `cncf-stack` (see note below)

## Notes

- Follow-ups: Envoy + `ext_authz` are tracked in #228 (the `gitea-gateway` is a lightweight precursor to that enforcement layer).
- **Folder naming:** this uses `demos/cncf-stack/` (matching issue #227). The earlier placeholder PR #231 created `demos/cncf-demo/`; these should be reconciled.

Closes #227
