### PR TITLE
chore: add identity-spec-contributors and identity-spec-maintainers as codeowners for demos/

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,3 +4,6 @@
 #
 #####################################################
 * @jadiaconu @beryder @mkedjour @rafaelsilva29 @copasseron @hmuyal @mayannuz @agntcy/identity-maintainers
+
+# Demos directory
+demos/ @agntcy/identity-spec-contributors @agntcy/identity-spec-maintainers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,4 +6,4 @@
 * @jadiaconu @beryder @mkedjour @rafaelsilva29 @copasseron @hmuyal @mayannuz @agntcy/identity-maintainers
 
 # Demos directory
-demos/ @agntcy/identity-spec-contributors @agntcy/identity-spec-maintainers
+demos/ @agntcy/identity-spec-contributors @agntcy/identity-spec-maintainers @agntcy/identity-service-contributors


### PR DESCRIPTION
## Summary
- Adds `@agntcy/identity-spec-contributors` and `@agntcy/identity-spec-maintainers` as required reviewers for the `demos/` directory
- Enables PR approval and merge control for changes under `demos/`

## Test plan
- [ ] Verify CODEOWNERS entry correctly gates PRs touching `demos/` to require review from identity-spec-contributors or identity-spec-maintainers

🤖 Generated with [Claude Code](https://claude.com/claude-code)